### PR TITLE
Fix broken doc and blog links

### DIFF
--- a/_posts/2015-04-06-Simplified-Workspace-Creation.md
+++ b/_posts/2015-04-06-Simplified-Workspace-Creation.md
@@ -29,7 +29,7 @@ update your `~/.bazelrc` file.
 finds/generates, you can create a `tools/` directory in your project and
 Bazel will attempt to use that instead of the system-wide one.
 
-See the [getting started](https://docs.bazel.build/versions/master/getting-started.html) docs for more info about
+See the [getting started](site.docs_site_url/getting-started.html) docs for more info about
 setting up your workspace.
 
 Let us know if you have any questions or issues on the

--- a/_posts/2015-04-06-Simplified-Workspace-Creation.md
+++ b/_posts/2015-04-06-Simplified-Workspace-Creation.md
@@ -29,7 +29,7 @@ update your `~/.bazelrc` file.
 finds/generates, you can create a `tools/` directory in your project and
 Bazel will attempt to use that instead of the system-wide one.
 
-See the [getting started](site.docs_site_url/getting-started.html) docs for more info about
+See the [getting started]({{ site.docs_site_url }}/getting-started.html) docs for more info about
 setting up your workspace.
 
 Let us know if you have any questions or issues on the

--- a/_posts/2015-04-06-Simplified-Workspace-Creation.md
+++ b/_posts/2015-04-06-Simplified-Workspace-Creation.md
@@ -29,7 +29,7 @@ update your `~/.bazelrc` file.
 finds/generates, you can create a `tools/` directory in your project and
 Bazel will attempt to use that instead of the system-wide one.
 
-See the [getting started]({{ site_root }}/docs/getting-started.html) docs for more info about
+See the [getting started](https://docs.bazel.build/versions/master/getting-started.html) docs for more info about
 setting up your workspace.
 
 Let us know if you have any questions or issues on the

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -20,7 +20,7 @@ $ cd tiny-workspace
 ```
 
 Make sure you've
-[downloaded and installed Bazel](http://bazel.build/docs/install.html) and have the
+[downloaded and installed Bazel](https://docs.bazel.build/versions/master/install.html) and have the
 following line to your _~/.bazelrc_:
 
 ```
@@ -64,4 +64,4 @@ Now the resulting graph is just:
 Much neater!
 
 If you're interested in further refining your query, check out the
-[docs on querying](/docs/query.html).
+[docs on querying](https://docs.bazel.build/versions/master/query.html).

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -20,7 +20,7 @@ $ cd tiny-workspace
 ```
 
 Make sure you've
-[downloaded and installed Bazel](https://docs.bazel.build/versions/master/install.html) and have the
+[downloaded and installed Bazel](site.docs_site_url/install.html) and have the
 following line to your _~/.bazelrc_:
 
 ```
@@ -64,4 +64,4 @@ Now the resulting graph is just:
 Much neater!
 
 If you're interested in further refining your query, check out the
-[docs on querying](https://docs.bazel.build/versions/master/query.html).
+[docs on querying](site.docs_site_url/versions/master/query.html).

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -20,7 +20,7 @@ $ cd tiny-workspace
 ```
 
 Make sure you've
-[downloaded and installed Bazel](site.docs_site_url/install.html) and have the
+[downloaded and installed Bazel]({{ site.docs_site_url }}/install.html) and have the
 following line to your _~/.bazelrc_:
 
 ```
@@ -64,4 +64,4 @@ Now the resulting graph is just:
 Much neater!
 
 If you're interested in further refining your query, check out the
-[docs on querying](site.docs_site_url/versions/master/query.html).
+[docs on querying]({{ site.docs_site_url }}/versions/master/query.html).

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -64,4 +64,4 @@ Now the resulting graph is just:
 Much neater!
 
 If you're interested in further refining your query, check out the
-[docs on querying]({{ site.docs_site_url }}/versions/master/query.html).
+[docs on querying]({{ site.docs_site_url }}/query.html).

--- a/_posts/2015-07-01-Configuration-File.md
+++ b/_posts/2015-07-01-Configuration-File.md
@@ -24,4 +24,4 @@ three paths to master rc files that are read in the following order:
   2. `/path/to/bazel.bazelrc` (alongside bazel rc file), and
   3. `/etc/bazel.bazelrc` (system-wide bazel rc file).
 
-The complete documentation on rc file is [here](https://docs.bazel.build/versions/master/bazel-user-manual.html#bazelrc).
+The complete documentation on rc file is [here](site.docs_site_url/bazel-user-manual.html#bazelrc).

--- a/_posts/2015-07-01-Configuration-File.md
+++ b/_posts/2015-07-01-Configuration-File.md
@@ -24,4 +24,4 @@ three paths to master rc files that are read in the following order:
   2. `/path/to/bazel.bazelrc` (alongside bazel rc file), and
   3. `/etc/bazel.bazelrc` (system-wide bazel rc file).
 
-The complete documentation on rc file is [here](site.docs_site_url/bazel-user-manual.html#bazelrc).
+The complete documentation on rc file is [here]({{ site.docs_site_url }}/bazel-user-manual.html#bazelrc).

--- a/_posts/2015-07-01-Configuration-File.md
+++ b/_posts/2015-07-01-Configuration-File.md
@@ -24,4 +24,4 @@ three paths to master rc files that are read in the following order:
   2. `/path/to/bazel.bazelrc` (alongside bazel rc file), and
   3. `/etc/bazel.bazelrc` (system-wide bazel rc file).
 
-The complete documentation on rc file is [here](http://bazel.build/docs/bazel-user-manual.html#bazelrc).
+The complete documentation on rc file is [here](https://docs.bazel.build/versions/master/bazel-user-manual.html#bazelrc).

--- a/_posts/2015-07-28-docker_build.md
+++ b/_posts/2015-07-28-docker_build.md
@@ -59,7 +59,7 @@ ADD bazinga /
 VOLUMES /asdf
 ```
 
-Using [remote repositories](site.docs_site_url/external.html), it is possible
+Using [remote repositories]({{ site.docs_site_url }}/external.html), it is possible
 to fetch the various base image for the web and we are working on providing a
 `docker_pull` rule to interact more fluently with existing images.
 

--- a/_posts/2015-07-28-docker_build.md
+++ b/_posts/2015-07-28-docker_build.md
@@ -59,7 +59,7 @@ ADD bazinga /
 VOLUMES /asdf
 ```
 
-Using [remote repositories](http://bazel.build/docs/external.html), it is possible
+Using [remote repositories](https://docs.bazel.build/versions/master/external.html), it is possible
 to fetch the various base image for the web and we are working on providing a
 `docker_pull` rule to interact more fluently with existing images.
 

--- a/_posts/2015-07-28-docker_build.md
+++ b/_posts/2015-07-28-docker_build.md
@@ -59,7 +59,7 @@ ADD bazinga /
 VOLUMES /asdf
 ```
 
-Using [remote repositories](https://docs.bazel.build/versions/master/external.html), it is possible
+Using [remote repositories](site.docs_site_url/external.html), it is possible
 to fetch the various base image for the web and we are working on providing a
 `docker_pull` rule to interact more fluently with existing images.
 

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -24,14 +24,14 @@ Our beta release provides:
 * Binary releases for
   [Linux and OS X](https://github.com/bazelbuild/bazel/releases).
 * Support for building and testing C++, Java, Python, Rust,
-  [and more](site.docs_site_url/be/overview.html).
+  [and more]({{ site.docs_site_url }}/be/overview.html).
 * Support for building Docker images, Android apps, and iOS apps.
 * Support for using libraries from
-  [Maven, GitHub, and more](site.docs_site_url/external.html).
-* [A robust API](site.docs_site_url/skylark/index.html) for adding your own
+  [Maven, GitHub, and more]({{ site.docs_site_url }}/external.html).
+* [A robust API]({{ site.docs_site_url }}/skylark/index.html) for adding your own
   build rules.
 
-Check out the [tutorial app](site.docs_site_url/tutorial/index.html) to see a
+Check out the [tutorial app]({{ site.docs_site_url }}/tutorial/index.html) to see a
 working example using several languages.
 
 We still have a long way to go.  Looking ahead towards our 1.0.0 release, we

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -24,14 +24,14 @@ Our beta release provides:
 * Binary releases for
   [Linux and OS X](https://github.com/bazelbuild/bazel/releases).
 * Support for building and testing C++, Java, Python, Rust,
-  [and more](http://bazel.build/docs/be/overview.html).
+  [and more](https://docs.bazel.build/versions/master/be/overview.html).
 * Support for building Docker images, Android apps, and iOS apps.
 * Support for using libraries from
-  [Maven, GitHub, and more](http://bazel.build/docs/external.html).
-* [A robust API](http://bazel.build/docs/skylark/index.html) for adding your own
+  [Maven, GitHub, and more](https://docs.bazel.build/versions/master/external.html).
+* [A robust API](https://docs.bazel.build/versions/master/skylark/index.html) for adding your own
   build rules.
 
-Check out the [tutorial app](http://bazel.build/docs/tutorial/index.html) to see a
+Check out the [tutorial app](https://docs.bazel.build/versions/master/tutorial/index.html) to see a
 working example using several languages.
 
 We still have a long way to go.  Looking ahead towards our 1.0.0 release, we

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -31,8 +31,11 @@ Our beta release provides:
 * [A robust API]({{ site.docs_site_url }}/skylark/index.html) for adding your own
   build rules.
 
-Check out the [tutorial app]({{ site.docs_site_url }}/tutorial/index.html) to see a
-working example using several languages.
+Check out the tutorails for working examples using several languages:
+* [Build a Java Project]({{ site.docs_site_url }}/tutorial/java.html)
+* [Build a C++ Project]({{ site.docs_site_url }}/tutorial/cpp.html)
+* [Build an Android App]({{ site.docs_site_url }}/tutorial/android-app.html)
+* [Build an iOS App]({{ site.docs_site_url }}/tutorial/ios-app.html)
 
 We still have a long way to go.  Looking ahead towards our 1.0.0 release, we
 plan to provide Windows support, distributed caching, and Go support among other

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -24,14 +24,14 @@ Our beta release provides:
 * Binary releases for
   [Linux and OS X](https://github.com/bazelbuild/bazel/releases).
 * Support for building and testing C++, Java, Python, Rust,
-  [and more](https://docs.bazel.build/versions/master/be/overview.html).
+  [and more](site.docs_site_url/be/overview.html).
 * Support for building Docker images, Android apps, and iOS apps.
 * Support for using libraries from
-  [Maven, GitHub, and more](https://docs.bazel.build/versions/master/external.html).
-* [A robust API](https://docs.bazel.build/versions/master/skylark/index.html) for adding your own
+  [Maven, GitHub, and more](site.docs_site_url/external.html).
+* [A robust API](site.docs_site_url/skylark/index.html) for adding your own
   build rules.
 
-Check out the [tutorial app](https://docs.bazel.build/versions/master/tutorial/index.html) to see a
+Check out the [tutorial app](site.docs_site_url/tutorial/index.html) to see a
 working example using several languages.
 
 We still have a long way to go.  Looking ahead towards our 1.0.0 release, we

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -141,7 +141,8 @@ These return codes can be used to determine the reason for a failure
 code 3 as unstable, and other non zero code as failed).
 
 You can also control how much information about test results Bazel prints out
-with the [`--test_output` flag](https://docs.bazel.build/versions/master/bazel-user-manual.html#flag--test_output).
+with the [`--test_output` flag](Finally, Bazel's built-in [JUnit test runner](site.docs_site_urlsrc/java_tools/junitrunner)
+/bazel-user-manual.html#flag--test_output).
 Generally, printing the output of test that fails with `--test_output=errors` is
 a good setting for a CI system.
 

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -153,6 +153,6 @@ Other tests also get [a basic XML output file](https://github.com/bazelbuild/baz
 that contains only the result of the test (success or failure).
 
 To get your test results, you can also use the
-[Bazel dashboard](https://blog.bazel.build/2015/07/29/dashboard-dogfood.html),
+[Bazel dashboard]({{ site.blog_site_url }}/2015/07/29/dashboard-dogfood.html),
 an optional system that automatically uploads Bazel test results to a shared
 server.

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -141,7 +141,7 @@ These return codes can be used to determine the reason for a failure
 code 3 as unstable, and other non zero code as failed).
 
 You can also control how much information about test results Bazel prints out
-with the [`--test_output` flag](http://bazel.build/docs/bazel-user-manual.html#flag--test_output).
+with the [`--test_output` flag](https://docs.bazel.build/versions/master/bazel-user-manual.html#flag--test_output).
 Generally, printing the output of test that fails with `--test_output=errors` is
 a good setting for a CI system.
 
@@ -153,6 +153,6 @@ Other tests also get [a basic XML output file](https://github.com/bazelbuild/baz
 that contains only the result of the test (success or failure).
 
 To get your test results, you can also use the
-[Bazel dashboard](http://bazel.build/blog/2015/07/29/dashboard-dogfood.html),
+[Bazel dashboard](https://blog.bazel.build/2015/07/29/dashboard-dogfood.html),
 an optional system that automatically uploads Bazel test results to a shared
 server.

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -141,8 +141,7 @@ These return codes can be used to determine the reason for a failure
 code 3 as unstable, and other non zero code as failed).
 
 You can also control how much information about test results Bazel prints out
-with the [`--test_output` flag](Finally, Bazel's built-in [JUnit test runner](https://github.com/bazelbuild/bazel/blob/master/src/java_tools/junitrunner)
-/bazel-user-manual.html#flag--test_output).
+with the [`--test_output` flag]({{ site.docs_site_url }}/bazel-user-manual.html#flag--test_output).
 Generally, printing the output of test that fails with `--test_output=errors` is
 a good setting for a CI system.
 

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -141,7 +141,7 @@ These return codes can be used to determine the reason for a failure
 code 3 as unstable, and other non zero code as failed).
 
 You can also control how much information about test results Bazel prints out
-with the [`--test_output` flag](Finally, Bazel's built-in [JUnit test runner](site.docs_site_urlsrc/java_tools/junitrunner)
+with the [`--test_output` flag](Finally, Bazel's built-in [JUnit test runner](https://github.com/bazelbuild/bazel/blob/master/src/java_tools/junitrunner)
 /bazel-user-manual.html#flag--test_output).
 Generally, printing the output of test that fails with `--test_output=errors` is
 a good setting for a CI system.

--- a/_posts/2016-02-23-0.2.0-release.md
+++ b/_posts/2016-02-23-0.2.0-release.md
@@ -42,7 +42,7 @@ list](https://groups.google.com/forum/#!forum/bazel-discuss).
 ### Go build and test support
 
 There is now Go language support, see [the
-documentation](https://docs.bazel.build/versions/master/be/go.html) for details.
+documentation](site.docs_site_url/be/go.html) for details.
 
 ### Open sourcing tests
 

--- a/_posts/2016-02-23-0.2.0-release.md
+++ b/_posts/2016-02-23-0.2.0-release.md
@@ -42,7 +42,7 @@ list](https://groups.google.com/forum/#!forum/bazel-discuss).
 ### Go build and test support
 
 There is now Go language support, see [the
-documentation](site.docs_site_url/be/go.html) for details.
+documentation]({{ site.docs_site_url }}/be/go.html) for details.
 
 ### Open sourcing tests
 

--- a/_posts/2016-02-23-0.2.0-release.md
+++ b/_posts/2016-02-23-0.2.0-release.md
@@ -42,7 +42,7 @@ list](https://groups.google.com/forum/#!forum/bazel-discuss).
 ### Go build and test support
 
 There is now Go language support, see [the
-documentation](http://bazel.build/docs/be/go.html) for details.
+documentation](https://docs.bazel.build/versions/master/be/go.html) for details.
 
 ### Open sourcing tests
 

--- a/_posts/2016-03-18-sandbox-easier-debug.md
+++ b/_posts/2016-03-18-sandbox-easier-debug.md
@@ -6,7 +6,7 @@ title: Easier Debugging of Sandbox Failures
 We have often heard that debugging failed execution due to issues with the sandbox is difficult and requires knowledge of the sandboxing code of Bazel to actually understand what’s happening. With [these changes](https://github.com/bazelbuild/bazel/commit/40ee9de052e3bb8cf5a59eeff3936148e1f55e69), we hope that you will be able to solve common issues easier on your own and make debugging easier.
 
 
-If you don’t know much about Bazel sandbox, you might want to read [this blog post](http://bazel.build/blog/2015/09/11/sandboxing.html)
+If you don’t know much about Bazel sandbox, you might want to read [this blog post](https://blog.bazel.build/2015/09/11/sandboxing.html)
 
 
 ## What we did:

--- a/_posts/2016-03-18-sandbox-easier-debug.md
+++ b/_posts/2016-03-18-sandbox-easier-debug.md
@@ -6,7 +6,7 @@ title: Easier Debugging of Sandbox Failures
 We have often heard that debugging failed execution due to issues with the sandbox is difficult and requires knowledge of the sandboxing code of Bazel to actually understand what’s happening. With [these changes](https://github.com/bazelbuild/bazel/commit/40ee9de052e3bb8cf5a59eeff3936148e1f55e69), we hope that you will be able to solve common issues easier on your own and make debugging easier.
 
 
-If you don’t know much about Bazel sandbox, you might want to read [this blog post](https://blog.bazel.build/2015/09/11/sandboxing.html)
+If you don’t know much about Bazel sandbox, you might want to read [this blog post]({{ site.blog_site_url }}/2015/09/11/sandboxing.html)
 
 
 ## What we did:

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -15,7 +15,7 @@ support.
 
 In this release, we made it possible to [generate information for IDEs from
 Bazel build files](https://blog.bazel.build/2016/06/10/ide-support.html) using
-[Skylark aspects](https://docs.bazel.build/versions/master/skylark/aspects.html).
+[Skylark aspects](site.docs_site_url/skylark/aspects.html).
 
 Simultaneous with Bazel 0.3 release, we are announcing the availability of two
 projects integrating Bazel with different IDEs:
@@ -29,7 +29,7 @@ projects integrating Bazel with different IDEs:
 
 ### Windows support
 
-Bazel can now bootstrap on [Windows](https://docs.bazel.build/versions/master/windows.html) without
+Bazel can now bootstrap on [Windows](site.docs_site_url/windows.html) without
 admin privilege and can use the Microsoft Visual C++ toolchain. Windows
 support is still highly experimental and we have identified
 [several issues](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
@@ -46,7 +46,7 @@ with Alpha to enhance that support.
 ### Skylark remote repositories
 
 Remote repository rules can now be created using
-[Skylark](https://docs.bazel.build/versions/master/skylark/repository_rules.html). This can be used
+[Skylark](site.docs_site_url/repository_rules.html). This can be used
 to support your custom protocols, interfacing with new packaging systems or even
 do auto-configuration to use a toolchain on your local disk. We use it
 especially to have [a better out-of-the-box experience with C++ toolchains](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
@@ -55,7 +55,7 @@ especially to have [a better out-of-the-box experience with C++ toolchains](http
 
 * We just open-sourced our BUILD file formatter, [buildifier](https://github.com/bazelbuild/buildifier).
 * We now provide a Debian APT repository for installing bazel, see the
-  [installation guide](https://docs.bazel.build/versions/master/install.html) on how to use it.
+  [installation guide](site.docs_site_url/install.html) on how to use it.
 * Our JUnit test runner for Java tests (`--nolegacy_bazel_java_test`) is now the
   default.
 

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -14,7 +14,7 @@ support.
 ### IDE support
 
 In this release, we made it possible to [generate information for IDEs from
-Bazel build files](https://blog.bazel.build/2016/06/10/ide-support.html) using
+Bazel build files]({{ site.blog_site_url }}/2016/06/10/ide-support.html) using
 [Skylark aspects]({{ site.docs_site_url }}/skylark/aspects.html).
 
 Simultaneous with Bazel 0.3 release, we are announcing the availability of two
@@ -49,7 +49,7 @@ Remote repository rules can now be created using
 [Skylark]({{ site.docs_site_url }}/repository_rules.html). This can be used
 to support your custom protocols, interfacing with new packaging systems or even
 do auto-configuration to use a toolchain on your local disk. We use it
-especially to have [a better out-of-the-box experience with C++ toolchains](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
+especially to have [a better out-of-the-box experience with C++ toolchains]({{ site.blog_site_url }}/2016/03/31/autoconfiguration.html).
 
 ## Other major changes since 0.2.0
 
@@ -68,7 +68,7 @@ changes.
 Looking ahead to 0.4.0:
 
 * The last blockers for `--strategy=worker=Javac` will be resolved, making Java
-  builds [faster](https://blog.bazel.build/2015/12/10/java-workers.html).
+  builds [faster]({{ site.blog_site_url }}/2015/12/10/java-workers.html).
 * [Yue](https://github.com/hermione521) has made great progress in making
   [Ulf](https://github.com/ulfjack)'s prototype of [sandboxing for OS
   X](https://github.com/bazelbuild/bazel/tree/osx-sandbox-hardlinks) real.

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -15,7 +15,7 @@ support.
 
 In this release, we made it possible to [generate information for IDEs from
 Bazel build files](https://blog.bazel.build/2016/06/10/ide-support.html) using
-[Skylark aspects](site.docs_site_url/skylark/aspects.html).
+[Skylark aspects]({{ site.docs_site_url }}/skylark/aspects.html).
 
 Simultaneous with Bazel 0.3 release, we are announcing the availability of two
 projects integrating Bazel with different IDEs:
@@ -29,7 +29,7 @@ projects integrating Bazel with different IDEs:
 
 ### Windows support
 
-Bazel can now bootstrap on [Windows](site.docs_site_url/windows.html) without
+Bazel can now bootstrap on [Windows]({{ site.docs_site_url }}/windows.html) without
 admin privilege and can use the Microsoft Visual C++ toolchain. Windows
 support is still highly experimental and we have identified
 [several issues](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
@@ -46,7 +46,7 @@ with Alpha to enhance that support.
 ### Skylark remote repositories
 
 Remote repository rules can now be created using
-[Skylark](site.docs_site_url/repository_rules.html). This can be used
+[Skylark]({{ site.docs_site_url }}/repository_rules.html). This can be used
 to support your custom protocols, interfacing with new packaging systems or even
 do auto-configuration to use a toolchain on your local disk. We use it
 especially to have [a better out-of-the-box experience with C++ toolchains](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
@@ -55,7 +55,7 @@ especially to have [a better out-of-the-box experience with C++ toolchains](http
 
 * We just open-sourced our BUILD file formatter, [buildifier](https://github.com/bazelbuild/buildifier).
 * We now provide a Debian APT repository for installing bazel, see the
-  [installation guide](site.docs_site_url/install.html) on how to use it.
+  [installation guide]({{ site.docs_site_url }}/install.html) on how to use it.
 * Our JUnit test runner for Java tests (`--nolegacy_bazel_java_test`) is now the
   default.
 

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -14,8 +14,8 @@ support.
 ### IDE support
 
 In this release, we made it possible to [generate information for IDEs from
-Bazel build files](http://bazel.build/blog/2016/06/10/ide-support.html) using
-[Skylark aspects](http://bazel.build/docs/skylark/aspects.html).
+Bazel build files](https://blog.bazel.build/2016/06/10/ide-support.html) using
+[Skylark aspects](https://docs.bazel.build/versions/master/skylark/aspects.html).
 
 Simultaneous with Bazel 0.3 release, we are announcing the availability of two
 projects integrating Bazel with different IDEs:
@@ -29,7 +29,7 @@ projects integrating Bazel with different IDEs:
 
 ### Windows support
 
-Bazel can now bootstrap on [Windows](http://bazel.build/docs/windows.html) without
+Bazel can now bootstrap on [Windows](https://docs.bazel.build/versions/master/windows.html) without
 admin privilege and can use the Microsoft Visual C++ toolchain. Windows
 support is still highly experimental and we have identified
 [several issues](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
@@ -46,16 +46,16 @@ with Alpha to enhance that support.
 ### Skylark remote repositories
 
 Remote repository rules can now be created using
-[Skylark](http://bazel.build/docs/skylark/repository_rules.html). This can be used
+[Skylark](https://docs.bazel.build/versions/master/skylark/repository_rules.html). This can be used
 to support your custom protocols, interfacing with new packaging systems or even
 do auto-configuration to use a toolchain on your local disk. We use it
-especially to have [a better out-of-the-box experience with C++ toolchains](http://www.bazel.build/blog/2016/03/31/autoconfiguration.html).
+especially to have [a better out-of-the-box experience with C++ toolchains](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
 
 ## Other major changes since 0.2.0
 
 * We just open-sourced our BUILD file formatter, [buildifier](https://github.com/bazelbuild/buildifier).
 * We now provide a Debian APT repository for installing bazel, see the
-  [installation guide](http://bazel.build/docs/install.html) on how to use it.
+  [installation guide](https://docs.bazel.build/versions/master/install.html) on how to use it.
 * Our JUnit test runner for Java tests (`--nolegacy_bazel_java_test`) is now the
   default.
 
@@ -68,7 +68,7 @@ changes.
 Looking ahead to 0.4.0:
 
 * The last blockers for `--strategy=worker=Javac` will be resolved, making Java
-  builds [faster](http://www.bazel.build/blog/2015/12/10/java-workers.html).
+  builds [faster](https://blog.bazel.build/2015/12/10/java-workers.html).
 * [Yue](https://github.com/hermione521) has made great progress in making
   [Ulf](https://github.com/ulfjack)'s prototype of [sandboxing for OS
   X](https://github.com/bazelbuild/bazel/tree/osx-sandbox-hardlinks) real.

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -38,7 +38,7 @@ and actions. Applying an aspect to a build target creates a "shadow
 dependency graph" reflecting all transitive dependencies of that target,
 and the aspect's implementation determines the actions that Bazel executes
 while traversing that graph.
-The [documentation on aspects]({{ site.docs_site_url }}/master/skylark/aspects.html) explains this in more
+The [documentation on aspects]({{ site.docs_site_url }}/skylark/aspects.html) explains this in more
 detail.
 
 ## Architecture of a Bazel IDE plugin.
@@ -88,7 +88,7 @@ group (and hence only to the aspect) are built, and therefore that no
 unnecessary build steps are performed.
 
 The aspect uses the
-[`java` provider](https://docs.bazel.build/versions/master/skylark/lib/JavaSkylarkApiProvider.html) on the targets
+[`java` provider]({{ site.docs_site_url }}/skylark/lib/JavaSkylarkApiProvider.html) on the targets
 it applies to to access a variety of information about Java targets.
 
 

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -32,13 +32,13 @@ the artifacts, IDEs use it to provide code navigation, autocompletion and
 other code-aware features.
 
 In the 0.3.0 Bazel release, we are adding a new concept to Bazel -
-[_aspects_](site.docs_site_url/skylark/aspects.html).
+[_aspects_]({{ site.docs_site_url }}/skylark/aspects.html).
 Aspects allow augmenting build dependency graphs with additional information
 and actions. Applying an aspect to a build target creates a "shadow
 dependency graph" reflecting all transitive dependencies of that target,
 and the aspect's implementation determines the actions that Bazel executes
 while traversing that graph.
-The [documentation on aspects](site.docs_site_url/master/skylark/aspects.html) explains this in more
+The [documentation on aspects]({{ site.docs_site_url }}/master/skylark/aspects.html) explains this in more
 detail.
 
 ## Architecture of a Bazel IDE plugin.

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -32,13 +32,13 @@ the artifacts, IDEs use it to provide code navigation, autocompletion and
 other code-aware features.
 
 In the 0.3.0 Bazel release, we are adding a new concept to Bazel -
-[_aspects_](/docs/skylark/aspects.html).
+[_aspects_](https://docs.bazel.build/versions/master/skylark/aspects.html).
 Aspects allow augmenting build dependency graphs with additional information
 and actions. Applying an aspect to a build target creates a "shadow
 dependency graph" reflecting all transitive dependencies of that target,
 and the aspect's implementation determines the actions that Bazel executes
 while traversing that graph.
-The [documentation on aspects](/docs/skylark/aspects.html) explains this in more
+The [documentation on aspects](https://docs.bazel.build/versions/master/skylark/aspects.html) explains this in more
 detail.
 
 ## Architecture of a Bazel IDE plugin.
@@ -88,7 +88,7 @@ group (and hence only to the aspect) are built, and therefore that no
 unnecessary build steps are performed.
 
 The aspect uses the
-[`java` provider](/docs/skylark/lib/JavaSkylarkApiProvider.html) on the targets
+[`java` provider](https://docs.bazel.build/versions/master/skylark/lib/JavaSkylarkApiProvider.html) on the targets
 it applies to to access a variety of information about Java targets.
 
 

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -32,13 +32,13 @@ the artifacts, IDEs use it to provide code navigation, autocompletion and
 other code-aware features.
 
 In the 0.3.0 Bazel release, we are adding a new concept to Bazel -
-[_aspects_](https://docs.bazel.build/versions/master/skylark/aspects.html).
+[_aspects_](site.docs_site_url/skylark/aspects.html).
 Aspects allow augmenting build dependency graphs with additional information
 and actions. Applying an aspect to a build target creates a "shadow
 dependency graph" reflecting all transitive dependencies of that target,
 and the aspect's implementation determines the actions that Bazel executes
 while traversing that graph.
-The [documentation on aspects](https://docs.bazel.build/versions/master/skylark/aspects.html) explains this in more
+The [documentation on aspects](site.docs_site_url/master/skylark/aspects.html) explains this in more
 detail.
 
 ## Architecture of a Bazel IDE plugin.

--- a/_posts/2016-11-04-bazel-build.md
+++ b/_posts/2016-11-04-bazel-build.md
@@ -4,7 +4,7 @@ title: We are now bazel.build!
 ---
 
 As you might have seen either in our
-[0.4 announcement](https://blog.bazel.build/2016/11/02/0.4.0-release.html) or simply by going to
+[0.4 announcement]({{ site.blog_site_url }}/2016/11/02/0.4.0-release.html) or simply by going to
 our website, we have recently switched over to the
 [bazel.build](https://bazel.build) domain name.
 

--- a/_posts/2016-11-04-bazel-build.md
+++ b/_posts/2016-11-04-bazel-build.md
@@ -4,7 +4,7 @@ title: We are now bazel.build!
 ---
 
 As you might have seen either in our
-[0.4 announcement](/blog/2016/11/02/0.4.0-release.html) or simply by going to
+[0.4 announcement](https://blog.bazel.build/2016/11/02/0.4.0-release.html) or simply by going to
 our website, we have recently switched over to the
 [bazel.build](https://bazel.build) domain name.
 

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -3,21 +3,21 @@ layout: posts
 title: Invalidation of repository rules
 ---
 
-[Remote repositories](/docs/external.html) are the way to use dependencies from
+[Remote repositories](https://docs.bazel.build/versions/master/external.html) are the way to use dependencies from
 "outside" of the Bazel world in Bazel. Using them, you can download binaries from the
 internet or use some from your own host. You can even use
-[Skylark](/skylark/repository_rules.html) to define your own repository rules to depend
+[Skylark](https://docs.bazel.build/versions/master/skylark/repository_rules.html) to define your own repository rules to depend
 on a custom package manager or to implement
-[auto-configuration rules](/blog/2016/03/31/autoconfiguration.html).
+[auto-configuration rules](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
 
 This post explains when Skylark repositories are invalidated and hence when they are executed.
 
 ## Dependencies
 
 The implementation attribute of the
-[`repository_rule`](https://bazel.build/versions/master/docs/skylark/lib/globals.html#repository_rule)
+[`repository_rule`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#repository_rule)
 defines a function (the _fetch_ operation) that is executed inside a
-[Skyframe function](/designs/skyframe.html). This function is executed when
+[Skyframe function](https://www.bazel.build/designs/skyframe.html). This function is executed when
 one of its dependencies change.
 
 For repository that are declared `local` (set `local = True` in the call to the
@@ -35,8 +35,8 @@ dependencies change:
 
 - Skylark files needed to define the repository rule.
 - Declaration of the repository rule in the `WORKSPACE` file.
-- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`](https://bazel.build/versions/master/docs/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
-[`--action_env`](/docs/command-line-reference.html#flag--action_env) flag (but this
+- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
+[`--action_env`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--action_env) flag (but this
 flag will invalidate every action of the build).
 - Content of any file used and referred using a label (e.g., `//mypkg:label.txt` not `mypkg/label.txt`).
 
@@ -46,8 +46,8 @@ flag will invalidate every action of the build).
 
 First and foremost, declaring a repository `local` should be done only for rule that
 needs to be eagerly invalidated and are fast to update. For native rule, this is used only
-for [`local_repository`](/docs/be/workspace.html#local_repository) and
-[`new_local_repository`](/docs/be/workspace.html#new_local_repository).
+for [`local_repository`](https://docs.bazel.build/versions/master/be/workspace.html#local_repository) and
+[`new_local_repository`](https://docs.bazel.build/versions/master/be/workspace.html#new_local_repository).
 
 ### Put all slow operation at the end, resolve dependencies first
 

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -46,8 +46,8 @@ flag will invalidate every action of the build).
 
 First and foremost, declaring a repository `local` should be done only for rule that
 needs to be eagerly invalidated and are fast to update. For native rule, this is used only
-for [`local_repository`](https://docs.bazel.build/versions/master/be/workspace.html#local_repository) and
-[`new_local_repository`](https://docs.bazel.build/versions/master/be/workspace.html#new_local_repository).
+for [`local_repository`]({{ site.docs_site_url }}/be/workspace.html#local_repository) and
+[`new_local_repository`]({{ site.docs_site_url }}/be/workspace.html#new_local_repository).
 
 ### Put all slow operation at the end, resolve dependencies first
 

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -3,10 +3,10 @@ layout: posts
 title: Invalidation of repository rules
 ---
 
-[Remote repositories](https://docs.bazel.build/versions/master/external.html) are the way to use dependencies from
+[Remote repositories](site.docs_site_url/external.html) are the way to use dependencies from
 "outside" of the Bazel world in Bazel. Using them, you can download binaries from the
 internet or use some from your own host. You can even use
-[Skylark](https://docs.bazel.build/versions/master/skylark/repository_rules.html) to define your own repository rules to depend
+[Skylark](site.docs_site_url/skylark/repository_rules.html) to define your own repository rules to depend
 on a custom package manager or to implement
 [auto-configuration rules](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
 
@@ -15,7 +15,7 @@ This post explains when Skylark repositories are invalidated and hence when they
 ## Dependencies
 
 The implementation attribute of the
-[`repository_rule`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#repository_rule)
+[`repository_rule`](site.docs_site_url/skylark/lib/globals.html#repository_rule)
 defines a function (the _fetch_ operation) that is executed inside a
 [Skyframe function](https://www.bazel.build/designs/skyframe.html). This function is executed when
 one of its dependencies change.
@@ -35,8 +35,8 @@ dependencies change:
 
 - Skylark files needed to define the repository rule.
 - Declaration of the repository rule in the `WORKSPACE` file.
-- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`](https://docs.bazel.build/versions/master/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
-[`--action_env`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--action_env) flag (but this
+- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`](site.docs_site_url/master/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
+[`--action_env`](site.docs_site_url/master/command-line-reference.html#flag--action_env) flag (but this
 flag will invalidate every action of the build).
 - Content of any file used and referred using a label (e.g., `//mypkg:label.txt` not `mypkg/label.txt`).
 

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -3,10 +3,10 @@ layout: posts
 title: Invalidation of repository rules
 ---
 
-[Remote repositories](site.docs_site_url/external.html) are the way to use dependencies from
+[Remote repositories]({{ site.docs_site_url }}/external.html) are the way to use dependencies from
 "outside" of the Bazel world in Bazel. Using them, you can download binaries from the
 internet or use some from your own host. You can even use
-[Skylark](site.docs_site_url/skylark/repository_rules.html) to define your own repository rules to depend
+[Skylark]({{ site.docs_site_url }}/skylark/repository_rules.html) to define your own repository rules to depend
 on a custom package manager or to implement
 [auto-configuration rules](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
 
@@ -15,7 +15,7 @@ This post explains when Skylark repositories are invalidated and hence when they
 ## Dependencies
 
 The implementation attribute of the
-[`repository_rule`](site.docs_site_url/skylark/lib/globals.html#repository_rule)
+[`repository_rule`]({{ site.docs_site_url }}/skylark/lib/globals.html#repository_rule)
 defines a function (the _fetch_ operation) that is executed inside a
 [Skyframe function](https://www.bazel.build/designs/skyframe.html). This function is executed when
 one of its dependencies change.
@@ -35,8 +35,8 @@ dependencies change:
 
 - Skylark files needed to define the repository rule.
 - Declaration of the repository rule in the `WORKSPACE` file.
-- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`](site.docs_site_url/master/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
-[`--action_env`](site.docs_site_url/master/command-line-reference.html#flag--action_env) flag (but this
+- Value of any environment variable declared with the `environ` attribute of the [`repository_rule`]({{ site.docs_site_url }}/skylark/lib/globals.html#repository_rule) function. The value of those environment variable can be enforced from the command line with the
+[`--action_env`]({{ site.docs_site_url }}/command-line-reference.html#flag--action_env) flag (but this
 flag will invalidate every action of the build).
 - Content of any file used and referred using a label (e.g., `//mypkg:label.txt` not `mypkg/label.txt`).
 

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -8,7 +8,7 @@ title: Invalidation of repository rules
 internet or use some from your own host. You can even use
 [Skylark]({{ site.docs_site_url }}/skylark/repository_rules.html) to define your own repository rules to depend
 on a custom package manager or to implement
-[auto-configuration rules](https://blog.bazel.build/2016/03/31/autoconfiguration.html).
+[auto-configuration rules]({{ site.blog_site_url }}/2016/03/31/autoconfiguration.html).
 
 This post explains when Skylark repositories are invalidated and hence when they are executed.
 

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -5,13 +5,13 @@ title: Protocol Buffers in Bazel
 
 Bazel currently provides built-in rules for Java, JavaLite and C++.
 
-[`proto_library`](https://bazel.build/versions/master/docs/be/protocol-buffer.html#proto_library)
+[`proto_library`](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library)
 is a language-agnostic rule that describes relations between `.proto` files.
 
-[`java_proto_library`](https://bazel.build/versions/master/docs/be/java.html#java_proto_library),
-[`java_lite_proto_library`](https://bazel.build/versions/master/docs/be/java.html#java_lite_proto_library)
+[`java_proto_library`](https://docs.bazel.build/versions/master/be/java.html#java_proto_library),
+[`java_lite_proto_library`](https://docs.bazel.build/versions/master/be/java.html#java_lite_proto_library)
 and
-[`cc_proto_library`](https://bazel.build/versions/master/docs/be/c-cpp.html#cc_proto_library)
+[`cc_proto_library`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_proto_library)
 are rules that "attach" to `proto_library` and generate language-specific
 bindings.
 
@@ -189,7 +189,7 @@ repository](https://github.com/google/protobuf/blob/b4b0e304be5a68de3d0ee1af9b28
 ### Bazel Aspects
 
 The `X_proto_library` rules are implemented using [Bazel
-Aspects](https://bazel.build/versions/master/docs/skylark/aspects.html) to have
+Aspects](https://docs.bazel.build/versions/master/skylark/aspects.html) to have
 the best of two worlds -
 
 1.  Only need a single `X_proto_library` rule for an arbitrarily-large proto

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -5,13 +5,13 @@ title: Protocol Buffers in Bazel
 
 Bazel currently provides built-in rules for Java, JavaLite and C++.
 
-[`proto_library`](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library)
+[`proto_library`](site.docs_site_url/be/protocol-buffer.html#proto_library)
 is a language-agnostic rule that describes relations between `.proto` files.
 
-[`java_proto_library`](https://docs.bazel.build/versions/master/be/java.html#java_proto_library),
-[`java_lite_proto_library`](https://docs.bazel.build/versions/master/be/java.html#java_lite_proto_library)
+[`java_proto_library`](site.docs_site_url/be/java.html#java_proto_library),
+[`java_lite_proto_library`](site.docs_site_url/be/java.html#java_lite_proto_library)
 and
-[`cc_proto_library`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_proto_library)
+[`cc_proto_library`](site.docs_site_url/be/c-cpp.html#cc_proto_library)
 are rules that "attach" to `proto_library` and generate language-specific
 bindings.
 
@@ -189,7 +189,7 @@ repository](https://github.com/google/protobuf/blob/b4b0e304be5a68de3d0ee1af9b28
 ### Bazel Aspects
 
 The `X_proto_library` rules are implemented using [Bazel
-Aspects](https://docs.bazel.build/versions/master/skylark/aspects.html) to have
+Aspects](site.docs_site_url/skylark/aspects.html) to have
 the best of two worlds -
 
 1.  Only need a single `X_proto_library` rule for an arbitrarily-large proto

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -5,13 +5,13 @@ title: Protocol Buffers in Bazel
 
 Bazel currently provides built-in rules for Java, JavaLite and C++.
 
-[`proto_library`](site.docs_site_url/be/protocol-buffer.html#proto_library)
+[`proto_library`]({{ site.docs_site_url }}/be/protocol-buffer.html#proto_library)
 is a language-agnostic rule that describes relations between `.proto` files.
 
-[`java_proto_library`](site.docs_site_url/be/java.html#java_proto_library),
-[`java_lite_proto_library`](site.docs_site_url/be/java.html#java_lite_proto_library)
+[`java_proto_library`]({{ site.docs_site_url }}/be/java.html#java_proto_library),
+[`java_lite_proto_library`]({{ site.docs_site_url }}/be/java.html#java_lite_proto_library)
 and
-[`cc_proto_library`](site.docs_site_url/be/c-cpp.html#cc_proto_library)
+[`cc_proto_library`]({{ site.docs_site_url }}/be/c-cpp.html#cc_proto_library)
 are rules that "attach" to `proto_library` and generate language-specific
 bindings.
 
@@ -189,7 +189,7 @@ repository](https://github.com/google/protobuf/blob/b4b0e304be5a68de3d0ee1af9b28
 ### Bazel Aspects
 
 The `X_proto_library` rules are implemented using [Bazel
-Aspects](site.docs_site_url/skylark/aspects.html) to have
+Aspects]({{ site.docs_site_url }}/skylark/aspects.html) to have
 the best of two worlds -
 
 1.  Only need a single `X_proto_library` rule for an arbitrarily-large proto

--- a/_posts/2017-03-07-java-sandwich.md
+++ b/_posts/2017-03-07-java-sandwich.md
@@ -21,7 +21,7 @@ java_library(name = "bottom", deps = [":middle", ...], ...)
 ## Built-in support for Java
 
 In Skylark, an interface to built-in Java functionality is available via the `java_common` module.
-The full API can be found in [the documentation](https://bazel.build/versions/master/docs/skylark/lib/java_common.html).
+The full API can be found in [the documentation](https://docs.bazel.build/versions/master/skylark/lib/java_common.html).
 
 ### `java_common.compile`
 

--- a/_posts/2017-03-07-java-sandwich.md
+++ b/_posts/2017-03-07-java-sandwich.md
@@ -21,7 +21,7 @@ java_library(name = "bottom", deps = [":middle", ...], ...)
 ## Built-in support for Java
 
 In Skylark, an interface to built-in Java functionality is available via the `java_common` module.
-The full API can be found in [the documentation](https://docs.bazel.build/versions/master/skylark/lib/java_common.html).
+The full API can be found in [the documentation](site.docs_site_url/skylark/lib/java_common.html).
 
 ### `java_common.compile`
 

--- a/_posts/2017-03-07-java-sandwich.md
+++ b/_posts/2017-03-07-java-sandwich.md
@@ -21,7 +21,7 @@ java_library(name = "bottom", deps = [":middle", ...], ...)
 ## Built-in support for Java
 
 In Skylark, an interface to built-in Java functionality is available via the `java_common` module.
-The full API can be found in [the documentation](site.docs_site_url/skylark/lib/java_common.html).
+The full API can be found in [the documentation]({{ site.docs_site_url }}/skylark/lib/java_common.html).
 
 ### `java_common.compile`
 

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -52,11 +52,11 @@ java\_test.
 ### New rules
 
 New rules in Bazel:
-[proto\_library](site.docs_site_url/be/protocol-buffer.html#proto_library),
-[java\_lite\_proto\_library](site.docs_site_url/be/java.html#java_lite_proto_library),
-[java\_proto\_library](site.docs_site_url/be/java.html#java_proto_library)
+[proto\_library]({{ site.docs_site_url }}/be/protocol-buffer.html#proto_library),
+[java\_lite\_proto\_library]({{ site.docs_site_url }}/be/java.html#java_lite_proto_library),
+[java\_proto\_library]({{ site.docs_site_url }}/be/java.html#java_proto_library)
 and
-[cc\_proto\_library](site.docs_site_url/be/c-cpp.html#cc_proto_library).
+[cc\_proto\_library]({{ site.docs_site_url }}/be/c-cpp.html#cc_proto_library).
 
 ### New Apple rules
 
@@ -76,7 +76,7 @@ versions as they become available.
    documentation](https://developer.android.com/studio/preview/features/java8-support.html)
    for more details about Android's Java 8 language features.
 -  Multidex is now fully supported via
-   [android\_binary.multidex](site.docs_site_url/be/android.html#android_binary.multidex).
+   [android\_binary.multidex]({{ site.docs_site_url }}/be/android.html#android_binary.multidex).
 -  android\_ndk\_repository now supports Android NDK 13 and NDK 14.
 -  APKs are now signed with both APK Signature V1 and V2.
    See [Android
@@ -96,20 +96,20 @@ minor change compared to the implementation in this 0.5.0 release.
 ## Skylark
 
 -  Declared Providers are now implemented and
-   [documented](site.docs_site_url/skylark/rules.html#providers).
+   [documented]({{ site.docs_site_url }}/skylark/rules.html#providers).
    They enable more robust and clearly defined interfaces between different
    rules and aspects. We recommend using them for all rules and aspects.
 -  The type formerly known as 'set' is now called 'depset'. Depsets make your
    rules perform much better, allowing rules memory consumption to scale
    linearly instead of quadratically with build graph size - make sure you have
    read the
-   [documentation on depsets](site.docs_site_url/skylark/depsets.html).
+   [documentation on depsets]({{ site.docs_site_url }}/skylark/depsets.html).
 
 ## Finally...
 
 A big thank you to our community for your continued support.
 Particular shout-outs to Peter Mounce for the [Chocolatey Windows
-package](site.docs_site_url/install-windows.html) and Yuki
+package]({{ site.docs_site_url }}/install-windows.html) and Yuki
 Yugui Sonoda for maintaining [rules\_go](https://github.com/bazelbuild/rules_go)
 (they both received an [open source peer
 bonus](https://opensource.googleblog.com/2017/03/the-latest-round-of-google-open-source.html)

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -24,7 +24,7 @@ APIs](https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvrobl
 As announced earlier, when using an install script, bazel now comes by default
 bundled with JDK 8. This means fewer steps required to install Bazel.  Read more
 about JDK 7 deprecation in [the related blog
-post](https://bazel.build/blog/2017/04/21/JDK7-deprecation.html).
+post](https://blog.bazel.build/2017/04/21/JDK7-deprecation.html).
 
 ### Windows support: now in beta
 
@@ -52,11 +52,11 @@ java\_test.
 ### New rules
 
 New rules in Bazel:
-[proto\_library](https://bazel.build/versions/master/docs/be/protocol-buffer.html#proto_library),
-[java\_lite\_proto\_library](https://bazel.build/versions/master/docs/be/java.html#java_lite_proto_library),
-[java\_proto\_library](https://bazel.build/versions/master/docs/be/java.html#java_proto_library)
+[proto\_library](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library),
+[java\_lite\_proto\_library](https://docs.bazel.build/versions/master/be/java.html#java_lite_proto_library),
+[java\_proto\_library](https://docs.bazel.build/versions/master/be/java.html#java_proto_library)
 and
-[cc\_proto\_library](https://bazel.build/versions/master/docs/be/c-cpp.html#cc_proto_library).
+[cc\_proto\_library](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_proto_library).
 
 ### New Apple rules
 
@@ -76,7 +76,7 @@ versions as they become available.
    documentation](https://developer.android.com/studio/preview/features/java8-support.html)
    for more details about Android's Java 8 language features.
 -  Multidex is now fully supported via
-   [android\_binary.multidex](https://bazel.build/versions/master/docs/be/android.html#android_binary.multidex).
+   [android\_binary.multidex](https://docs.bazel.build/versions/master/be/android.html#android_binary.multidex).
 -  android\_ndk\_repository now supports Android NDK 13 and NDK 14.
 -  APKs are now signed with both APK Signature V1 and V2.
    See [Android
@@ -96,20 +96,20 @@ minor change compared to the implementation in this 0.5.0 release.
 ## Skylark
 
 -  Declared Providers are now implemented and
-   [documented](https://bazel.build/versions/master/docs/skylark/rules.html#providers).
+   [documented](https://docs.bazel.build/versions/master/skylark/rules.html#providers).
    They enable more robust and clearly defined interfaces between different
    rules and aspects. We recommend using them for all rules and aspects.
 -  The type formerly known as 'set' is now called 'depset'. Depsets make your
    rules perform much better, allowing rules memory consumption to scale
    linearly instead of quadratically with build graph size - make sure you have
    read the
-   [documentation on depsets](https://bazel.build/versions/master/docs/skylark/depsets.html).
+   [documentation on depsets](https://docs.bazel.build/versions/master/skylark/depsets.html).
 
 ## Finally...
 
 A big thank you to our community for your continued support.
 Particular shout-outs to Peter Mounce for the [Chocolatey Windows
-package](https://bazel.build/versions/master/docs/install-windows.html) and Yuki
+package](https://docs.bazel.build/versions/master/install-windows.html) and Yuki
 Yugui Sonoda for maintaining [rules\_go](https://github.com/bazelbuild/rules_go)
 (they both received an [open source peer
 bonus](https://opensource.googleblog.com/2017/03/the-latest-round-of-google-open-source.html)

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -52,11 +52,11 @@ java\_test.
 ### New rules
 
 New rules in Bazel:
-[proto\_library](https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library),
-[java\_lite\_proto\_library](https://docs.bazel.build/versions/master/be/java.html#java_lite_proto_library),
-[java\_proto\_library](https://docs.bazel.build/versions/master/be/java.html#java_proto_library)
+[proto\_library](site.docs_site_url/be/protocol-buffer.html#proto_library),
+[java\_lite\_proto\_library](site.docs_site_url/be/java.html#java_lite_proto_library),
+[java\_proto\_library](site.docs_site_url/be/java.html#java_proto_library)
 and
-[cc\_proto\_library](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_proto_library).
+[cc\_proto\_library](site.docs_site_url/be/c-cpp.html#cc_proto_library).
 
 ### New Apple rules
 
@@ -76,7 +76,7 @@ versions as they become available.
    documentation](https://developer.android.com/studio/preview/features/java8-support.html)
    for more details about Android's Java 8 language features.
 -  Multidex is now fully supported via
-   [android\_binary.multidex](https://docs.bazel.build/versions/master/be/android.html#android_binary.multidex).
+   [android\_binary.multidex](site.docs_site_url/be/android.html#android_binary.multidex).
 -  android\_ndk\_repository now supports Android NDK 13 and NDK 14.
 -  APKs are now signed with both APK Signature V1 and V2.
    See [Android
@@ -96,20 +96,20 @@ minor change compared to the implementation in this 0.5.0 release.
 ## Skylark
 
 -  Declared Providers are now implemented and
-   [documented](https://docs.bazel.build/versions/master/skylark/rules.html#providers).
+   [documented](site.docs_site_url/skylark/rules.html#providers).
    They enable more robust and clearly defined interfaces between different
    rules and aspects. We recommend using them for all rules and aspects.
 -  The type formerly known as 'set' is now called 'depset'. Depsets make your
    rules perform much better, allowing rules memory consumption to scale
    linearly instead of quadratically with build graph size - make sure you have
    read the
-   [documentation on depsets](https://docs.bazel.build/versions/master/skylark/depsets.html).
+   [documentation on depsets](site.docs_site_url/skylark/depsets.html).
 
 ## Finally...
 
 A big thank you to our community for your continued support.
 Particular shout-outs to Peter Mounce for the [Chocolatey Windows
-package](https://docs.bazel.build/versions/master/install-windows.html) and Yuki
+package](site.docs_site_url/install-windows.html) and Yuki
 Yugui Sonoda for maintaining [rules\_go](https://github.com/bazelbuild/rules_go)
 (they both received an [open source peer
 bonus](https://opensource.googleblog.com/2017/03/the-latest-round-of-google-open-source.html)

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -24,7 +24,7 @@ APIs](https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvrobl
 As announced earlier, when using an install script, bazel now comes by default
 bundled with JDK 8. This means fewer steps required to install Bazel.  Read more
 about JDK 7 deprecation in [the related blog
-post](https://blog.bazel.build/2017/04/21/JDK7-deprecation.html).
+post]({{ site.blog_site_url }}/2017/04/21/JDK7-deprecation.html).
 
 ### Windows support: now in beta
 


### PR DESCRIPTION
I've gone through and updated links to docs.bazel.build and blog.bazel.build.

Closes #24 