### PR TITLE
Clean-up authors

### DIFF
--- a/_posts/2015-04-06-Simplified-Workspace-Creation.md
+++ b/_posts/2015-04-06-Simplified-Workspace-Creation.md
@@ -35,3 +35,5 @@ setting up your workspace.
 Let us know if you have any questions or issues on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or
 [GitHub](https://github.com/bazelbuild/bazel).
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-04-10-bash-completion.md
+++ b/_posts/2015-04-10-bash-completion.md
@@ -49,3 +49,5 @@ of two parts:
 Let us know if you have any questions or issues on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or
 [GitHub](https://github.com/bazelbuild/bazel).
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-04-15-share-your-project.md
+++ b/_posts/2015-04-15-share-your-project.md
@@ -15,4 +15,6 @@ the following information:
 5. Any other info or comments you have!
 
 If you don't want your project publicly listed, we'd still love to hear about
-it. Please [email us](mailto:kchodorow@google.com) directly and let us know.
+it. Please [email us](mailto:bazel-core@googlegroups.com) directly and let us know.
+
+*By [Kristina Chodorow](https://www.kchodorow.com/)*

--- a/_posts/2015-04-22-thank-you-stickers.md
+++ b/_posts/2015-04-22-thank-you-stickers.md
@@ -18,3 +18,5 @@ Let us know if you've done any of the following and we'll send you stickers:
 * Are in the process of doing any of the things above.
 
 Thanks for your contributions, we really appreciate them.
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -65,3 +65,5 @@ Much neater!
 
 If you're interested in further refining your query, check out the
 [docs on querying]({{ site.docs_site_url }}/query.html).
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-06-25-ErrorProne.md
+++ b/_posts/2015-06-25-ErrorProne.md
@@ -15,3 +15,5 @@ You can also tune the checks error-prone will perform by using the
 
 See the [documentation of Error Prone](http://errorprone.info/docs/installation) for more
 on Error Prone.
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-01-Configuration-File.md
+++ b/_posts/2015-07-01-Configuration-File.md
@@ -25,3 +25,5 @@ three paths to master rc files that are read in the following order:
   3. `/etc/bazel.bazelrc` (system-wide bazel rc file).
 
 The complete documentation on rc file is [here]({{ site.docs_site_url }}/bazel-user-manual.html#bazelrc).
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-08-Java-Configuration.md
+++ b/_posts/2015-07-08-Java-Configuration.md
@@ -42,3 +42,4 @@ In the future, toolchain rules should be the configuration points for all
 the languages but it is a long road. We also want to make it easier to
 rebind the toolchain using the `bind` rule in the WORKSPACE file.
 
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-23-tree-trimming.md
+++ b/_posts/2015-07-23-tree-trimming.md
@@ -50,3 +50,5 @@ form, so the "maybe dirty" node will end up being marked as "yes, dirty" and
 re-evaluated (and so on up the tree).  However, Bazel's build graph lets you
 compile the bare minimum for a well-structured library, and in some cases avoid
 compilations altogether.
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-07-28-docker_build.md
+++ b/_posts/2015-07-28-docker_build.md
@@ -64,4 +64,6 @@ to fetch the various base image for the web and we are working on providing a
 `docker_pull` rule to interact more fluently with existing images.
 
 You can learn more about this docker support
-[here](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/docker/README.md).
+[here](https://github.com/bazelbuild/docker_rules/blob/master/README.md).
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-29-dashboard-dogfood.md
+++ b/_posts/2015-07-29-dashboard-dogfood.md
@@ -35,3 +35,5 @@ for documentation.
 
 This is very much a work in progress. Please let us know if you have any
 questions, comments, or feedback.
+
+*By [Kristina Chodorow](https://www.kchodorow.com)

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -46,4 +46,4 @@ free to contact us with questions or feedback on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or IRC
 (#bazel on freenode).
 
-_By Jeff Cox, Bazel team_
+*By Jeff Cox, Bazel team*

--- a/_posts/2015-09-11-sandboxing.md
+++ b/_posts/2015-09-11-sandboxing.md
@@ -82,3 +82,5 @@ attribute to `genrule` or `*_test` calls.
 If you're writing a custom rule in Skylark, then you cannot currently opt out.
 Instead, please [file a bug](https://github.com/bazelbuild/bazel/issues) and
 we'll help you make it work.
+
+*By [Ulf Adams](https://github.com/ulfjack)* and [Philipp Wollermann](https://github.com/philwo)

--- a/_posts/2015-12-10-java-workers.md
+++ b/_posts/2015-12-10-java-workers.md
@@ -15,3 +15,5 @@ We’ve tried the persistent JavaBuilder for a variety of builds and are seeing 
 If you often build Java code, we’d like you to give it a try. Just pass `--strategy=Javac=worker` to enable it or add `build --strategy=Javac=worker` to the .bazelrc in your home directory or in your workspace. Check the WorkerOptions class for [flags to further tune the workers’ behavior](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java) or run “bazel help” and look for the “Strategy options” category. Let us know how it works for you.
 
 We’re currently using a simple [protobuf-based protocol](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto) to communicate with the worker process. Let us know if you want to add support for more compilers; in many cases, you can do that without any Bazel changes. However, the protocol is still subject to change based on your feedback.
+
+*By [Philipp Wollermann](https://github.com/philwo)*

--- a/_posts/2015-3-27-Hello-World.md
+++ b/_posts/2015-3-27-Hello-World.md
@@ -5,3 +5,5 @@ title: Hello World
 
 Welcome to the Bazel blog!  We'll be using this forum for news and
 announcements.
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -152,7 +152,4 @@ with the `--nolegacy_bazel_java_test` flag (this will soon be the default).
 Other tests also get [a basic XML output file](https://github.com/bazelbuild/bazel/blob/master/tools/test/test-setup.sh#L54)
 that contains only the result of the test (success or failure).
 
-To get your test results, you can also use the
-[Bazel dashboard]({{ site.blog_site_url }}/2015/07/29/dashboard-dogfood.html),
-an optional system that automatically uploads Bazel test results to a shared
-server.
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-02-23-0.2.0-release.md
+++ b/_posts/2016-02-23-0.2.0-release.md
@@ -99,3 +99,5 @@ shout-outs to the following contributors:
   effort into the Scala rules, as well as being a tireless supporter on Twitter.
 
 Thank you all, keep the discussion and bug reports coming!
+
+*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2016-03-18-sandbox-easier-debug.md
+++ b/_posts/2016-03-18-sandbox-easier-debug.md
@@ -56,3 +56,5 @@ There will be the same error message about not finding your compiler, but after 
 For this example, we run our compiler in the sandbox again manually and the error message shows `No command ‘some-compiler’ found` - looking around, you notice that the compiler binary is missing. This means it was not part of the action inputs, because Bazel always mounts all action inputs into the sandbox - so you check out your Skylark rule and notice that this is indeed the case. Adding your compiler to the input files in your Skylark rule should thus fix the error.
 
 Next time you run bazel build, it should mount your compiler into the sandbox and thus find it correctly. If you get a different error, you could repeat the steps above.
+
+*By [Yue Gan](https://github.com/hermione521)*

--- a/_posts/2016-03-31-autoconfiguration.md
+++ b/_posts/2016-03-31-autoconfiguration.md
@@ -87,3 +87,5 @@ When creating a Skylark remote repository, a few things should be taken in consi
    package rule, a good name would probably be `xxx_package` (e.g., `pypi_package`). If
    you create an autoconfiguration rule, `xxx_configure` is probably the best name
    (e.g. `cc_configure`).
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -89,3 +89,5 @@ shout-outs to the following contributors:
   their use of Bazel.
 
 Thank you all, keep the discussion and bug reports coming!
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -91,4 +91,4 @@ The aspect uses the
 [`java` provider]({{ site.docs_site_url }}/skylark/lib/JavaSkylarkApiProvider.html) on the targets
 it applies to to access a variety of information about Java targets.
 
-
+*By [Dmitry Lomov](https://github.com/dslomov)*

--- a/_posts/2016-10-07-bazel-windows.md
+++ b/_posts/2016-10-07-bazel-windows.md
@@ -29,3 +29,4 @@ and let us know what works or what doesn't work yet, and what we can do better.
 
 We are looking forward to what you build (on Windows)!
 
+*By [Dmitry Lomov](https://github.com/dslomov)*

--- a/_posts/2016-10-20-intellij-support.md
+++ b/_posts/2016-10-20-intellij-support.md
@@ -28,3 +28,5 @@ or build directly from [source](https://github.com/bazelbuild/intellij).
 Detailed docs are available [here](https://ij.bazel.build).
 
 The plugins are currently Linux-only, with plans for Mac support in the future.
+
+*By [Brendan Douglas](https://github.com/brendandouglas)*

--- a/_posts/2016-11-02-0.4.0-release.md
+++ b/_posts/2016-11-02-0.4.0-release.md
@@ -60,3 +60,5 @@ A big thank you to our community for your continued support.  Particular shout-o
 
 
 Thank you all, keep the discussion and bug reports coming!
+
+*By [Helen Altshuler](https://github.com/helenalt)*

--- a/_posts/2016-11-04-bazel-build.md
+++ b/_posts/2016-11-04-bazel-build.md
@@ -13,3 +13,5 @@ what Bazel is for: building!
 
 Our old domain, [bazel.io](https://bazel.io), will redirect to
 [bazel.build](https://bazel.build) for the forseenable future.
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -86,3 +86,5 @@ the repositories.
 Therefore, if you think you should re-run if an environment variable changes (like
 for auto-configuration rules), you should declare those dependencies, or your user
 will have to do `bazel clean --expunge` each time they change their environment.
+
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -220,4 +220,4 @@ descriptor sets is available through the `proto.transitive_descriptor_sets`
 Skylark provider. See [documentation in
 ProtoSourcesProvider](https://github.com/bazelbuild/bazel/blob/5dbb23ba44ec0037cf0944b17716ea3f08a69c27/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourcesProvider.java#L121).
 
-_By [Carmi Grushko](https://github.com/cgrushko)_
+*By [Carmi Grushko](https://github.com/cgrushko)*

--- a/_posts/2017-02-28-google-summer-of-code.md
+++ b/_posts/2017-02-28-google-summer-of-code.md
@@ -28,4 +28,4 @@ If you have any question, please contact us on bazel-core@googlegroups.com
 
 I'm looking forward to hearing from you,
 
-_Laurent Le Brun, on behalf of the Bazel mentors._
+*By Laurent Le Brun, on behalf of the Bazel mentors.*

--- a/_posts/2017-03-07-java-sandwich.md
+++ b/_posts/2017-03-07-java-sandwich.md
@@ -187,4 +187,4 @@ Soon there will be support for use cases like this. Stay tuned!
 If you are interested in tracking the progress on Bazel Java sandwich you can
 subscribe to [this Github issue](https://github.com/bazelbuild/bazel/issues/2614).
 
-_[Irina Iancu](https://github.com/iirina), on behalf of the Bazel Java team_
+*By [Irina Iancu](https://github.com/iirina), on behalf of the Bazel Java team*

--- a/_posts/2017-03-21-design-of-skylark.md
+++ b/_posts/2017-03-21-design-of-skylark.md
@@ -93,4 +93,4 @@ may create a copy and modify it, though.
 
 In a future blog post, we'll take a look at the other features of the language.
 
-_By [Laurent Le Brun](https://github.com/laurentlb)_
+*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2017-04-21-JDK7-deprecation.md
+++ b/_posts/2017-04-21-JDK7-deprecation.md
@@ -48,4 +48,4 @@ Java team at Google, in particular
 Special thanks to [Philipp Wollermann](https://github.com/philwo) who made this
 new installer possible.
 
-
+*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -120,3 +120,5 @@ Thank you all, keep the
 reports](https://github.com/bazelbuild/bazel/issues) coming!
 
 See the full list of changes on [GitHub](https://github.com/bazelbuild/bazel/releases/tag/0.5.0).
+
+*By [Steren Giannini](https://github.com/steren)*

--- a/_posts/2017-05-31-google-summer-of-code-2017.md
+++ b/_posts/2017-05-31-google-summer-of-code-2017.md
@@ -21,4 +21,4 @@ and follow [Harmandeep's blog](https://harmanio.wordpress.com/).
 
 A big thank you to everyone who applied!
 
-_By [Laurent Le Brun](https://github.com/laurentlb)_
+*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2017-07-20-backward-compatibility.md
+++ b/_posts/2017-07-20-backward-compatibility.md
@@ -1,4 +1,4 @@
----
+7---
 layout: posts
 title: Backward compatibility
 ---
@@ -63,4 +63,4 @@ To learn more about the changes we are doing, see the
 [backward compatibility page](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html).
 
 
-_By [Laurent Le Brun](https://github.com/laurentlb)_
+*By [Laurent Le Brun](https://github.com/laurentlb)*


### PR DESCRIPTION
 - Add authors when missing
 - Consistently use *By XXX...* everywhere
 - Remove reference to deprecated location