### PR TITLE
Fix search 404s

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
               </a>
             </li>
           </ul>
-          <form class="navbar-form navbar-right" action="/search.html" id="cse-search-box">
+          <form class="navbar-form navbar-right" action="https://bazel.build/search.html" id="cse-search-box">
             <div class="form-group">
               <input type="hidden" name="cx" value="012346921571893344015:xv_nfgpzbu4">
               <input type="hidden" name="cof" value="FORID:10">


### PR DESCRIPTION
Make the search post to https://bazel.build

Fixes #17 