### PR TITLE
Fix broken link

### DIFF
--- a/_posts/2017-09-27-release-cadence.md
+++ b/_posts/2017-09-27-release-cadence.md
@@ -3,7 +3,7 @@ layout: posts
 title: The New World of Bazel Releases
 ---
 
-Bazel has been open-sourced exactly [2.5 years ago](https://blog.bazel.build/2015/03/27/Hello-World.html). It continues to be quite a journey, and we are very happy we have acquired some fellow travellers: [many projects, organizations and companies that we all know and love](https://sites.google.com/corp/bazel.build/conference2017/agenda) rely on Bazel every day.
+Bazel has been open-sourced exactly [2.5 years ago](https://blog.bazel.build/2015/03/27/Hello-World.html). It continues to be quite a journey, and we are very happy we have acquired some fellow travellers: [many projects, organizations and companies that we all know and love](https://github.com/bazelbuild/bazel/wiki/Bazel-Users) rely on Bazel every day.
 
 As our community grows, we owe to it a transparent and predictable release process. So we are
 taking some steps to bring more clarity and order to the world of Bazel releases:


### PR DESCRIPTION
By making it point to a more relevant and permanent page: the list of Bazel users.