### PR TITLE
Remove js redirects

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,37 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }} - Bazel</title>
 
-    <script>
-      var current_url = window.location.href;
-      var bad_url = new RegExp("^https?://(bazelbuild.github.io/bazel|(www\.)?bazel.io)/");
-      if (bad_url.test(current_url)) {
-        window.location.replace(current_url.replace(bad_url, "https://bazel.build/"));
-      }
-      var http_url = new RegExp("^http://(www\.)?bazel.build/");
-      if (http_url.test(current_url)) {
-        window.location.replace(current_url.replace(http_url, "https://bazel.build/"));
-      }
-      // Do a shortcut so that be.bazel.build redirect to the build encyclopedia
-      var be_url = new RegExp("^https?://be(\.bazel.build)?/?");
-      if (be_url.test(current_url)) {
-        window.location.replace(current_url.replace(be_url, "https://bazel.build/docs/be/overview.html"));
-      }
-      var be_url = new RegExp("^https?://be(\.bazel.build)?/([a-zA-Z0-9_-]+)([/#](.*))?");
-      if (be_url.test(current_url)) {
-        window.location.replace(current_url.replace(be_url, "https://bazel.build/docs/be/$2.html#$4"));
-      }
-      // And a short to code reviews
-      var cr_url = new RegExp("^https?://cr(\.bazel.build)?/([0-9]+)")
-      if (cr_url.test(current_url)) {
-        window.location.replace(current_url.replace(cr_url, "https://bazel-review.googlesource.com/c/$2"));
-      }
-      // Code review dashboard
-      var cr_url = new RegExp("^https?://cr(\.bazel.build)?/?")
-      if (cr_url.test(current_url)) {
-        window.location.replace(current_url.replace(cr_url, "https://bazel-review.googlesource.com/"));
-      }
-    </script>
-
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
 
     <!-- Webfont -->


### PR DESCRIPTION
None of these domain patterns should ever hit blog.bazel.build -- remove redundant javascript redirect code