### PR TITLE
Update 2017-02-27-protocol-buffers.md

### DIFF
--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -46,6 +46,7 @@ The following satisfies these dependencies:
 http_archive(
     name = "com_google_protobuf",
     urls = ["https://github.com/google/protobuf/archive/b4b0e304be5a68de3d0ee1af9b286f958750f5e4.zip"],
+    strip_prefix = "protobuf-b4b0e304be5a68de3d0ee1af9b286f958750f5e4",
 )
 
 # cc_proto_library rules implicitly depend on @com_google_protobuf_cc//:cc_toolchain,
@@ -53,6 +54,7 @@ http_archive(
 http_archive(
     name = "com_google_protobuf_cc",
     urls = ["https://github.com/google/protobuf/archive/b4b0e304be5a68de3d0ee1af9b286f958750f5e4.zip"],
+    strip_prefix = "protobuf-b4b0e304be5a68de3d0ee1af9b286f958750f5e4",
 )
 
 # java_proto_library rules implicitly depend on @com_google_protobuf_java//:java_toolchain,
@@ -60,6 +62,7 @@ http_archive(
 http_archive(
     name = "com_google_protobuf_java",
     urls = ["https://github.com/google/protobuf/archive/b4b0e304be5a68de3d0ee1af9b286f958750f5e4.zip"],
+    strip_prefix = "protobuf-b4b0e304be5a68de3d0ee1af9b286f958750f5e4",
 )
 ```
 


### PR DESCRIPTION
Add strip_prefix to example WORKSPACE. Otherwise cryptic errors are returned trying to use it.

https://github.com/bazelbuild/bazel/issues/4191#issuecomment-347995381