### PR TITLE
Create an archive page for blogposts

### DIFF
--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -20,5 +20,5 @@
           <h2>Contribute</h2>
           <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p>
           <h2>Archive</h2>
-          <p>Find the list of all posts on the <a href="/archive.html">Archive</a> page.</p>
+          <p>Looking for a post? Find it on the <a href="/archive.html">Archive</a> page.</p>
         </div>

--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -20,5 +20,5 @@
           <h2>Contribute</h2>
           <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p>
           <h2>Archive</h2>
-          <p>All posts can be found on the <a href="/archive.html">Archive</a> page.</p>
+          <p>Find the list of all posts on the <a href="/archive.html">Archive</a> page.</p>
         </div>

--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -18,5 +18,7 @@
             <p>Delivered by <a href="https://feedburner.google.com" target="_blank">FeedBurner</a></p>
           </div>
           <h2>Contribute</h2>
-          <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p
+          <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p>
+          <h2>Archive</h2>
+          <p>All posts can be found on the <a href="/archive.html">Archive</a> page.</p>
         </div>

--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -3,7 +3,7 @@
           <p>For more frequent updates, follow us on Twitter.</p>
           <p><a class="twitter-follow-button" href="https://twitter.com/bazelbuild" data-show-count="false" data-size="large">Follow @bazelbuild</a></p>
           <h2>Discuss</h2>
-          <p>Join the discussion at our <a href="https://groups.google.com/forum/#!forum/bazel-discuss">mailing list</a>.</p>
+          <p>Join the discussion on our <a href="https://groups.google.com/forum/#!forum/bazel-discuss">mailing list</a>.</p>
           <h2>Subscribe</h2>
           <p>Subscribe to our blog via the <a href="/feed.xml">RSS Feed</a> or via email:</p>
           <div class="well">
@@ -20,5 +20,5 @@
           <h2>Contribute</h2>
           <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p>
           <h2>Archive</h2>
-          <p>Looking for a post? Find it on the <a href="/archive.html">Archive</a> page.</p>
+          <p>Looking for a specific post? Find it on the <a href="/archive.html">Archive</a> page.</p>
         </div>

--- a/archive.html
+++ b/archive.html
@@ -1,0 +1,38 @@
+---
+layout: posts
+title: Post Archive
+---
+
+<div>
+  <!-- Iterate through the posts -->
+  {% for post in site.posts %}
+    <!-- Get the year of the current post -->
+    {% assign yearOfPost = post.date | date: "%Y" %}
+
+    <!-- Check if this is the first iteration or the post's year doesn't match the current year section -->
+    {% if yearOfPost != currentYear %}
+
+      <!-- Close the list -->
+      {% unless forloop.first %}</ul>{% endunless %}
+
+      <!-- Create the year header -->
+      <h1>{{ yearOfPost }}</h1>
+      <ul>
+
+      <!-- Assign the current year section -->
+      {% assign currentYear = yearOfPost %}
+    {% endif %}
+
+    <!-- Create the list entry for the post -->
+    <li>
+      <a href="{{ post.url }}">
+        <span>{{ post.date | date: "%b %-d" }}</span> - {{ post.title }}
+      </a>
+    </li>
+
+    <!-- Close the list if it's the last post -->
+    {% if forloop.last %}
+      </ul>
+    {% endif %}
+  {% endfor %}
+</div>


### PR DESCRIPTION
I realized that there isn't an easy way to find a certain post, so I made an archive page with help from [this tutorial](http://chris.house/blog/building-a-simple-archive-page-with-jekyll/).

It looks pretty simple:

<img width="905" alt="screen shot 2018-03-31 at 5 40 54 pm" src="https://user-images.githubusercontent.com/347918/38167815-b0f3fa28-350a-11e8-8b0d-1a882980aef1.png">

I've also added a link to this page in the sidebar for easy access.