### PR TITLE
Fixed compilation error for archive page because of lack of date

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -22,7 +22,9 @@ enable_comments: true
           <div class="blog-post">
             <h1 class="blog-post-title">{{ page.title }}</h1>
             <div class="blog-post-meta">
-              <span class="text-muted">{{ page.date | date_to_long_string }}</a>
+              {% if page.date %}
+                <span class="text-muted">{{ page.date | date_to_long_string }}</a>
+              {% endif %}
             </div>
             <div class="blog-post-content">
               {{ content }}


### PR DESCRIPTION
@spomorski sorry, commit eb623a1a660e93331d2543f10b1b5013fec0fb3c broke `bazel build //:site`. This fixes it because the archive page doesn't have a date, but uses the layout for posts.