### PR TITLE
Fix table rendering

### DIFF
--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -16,6 +16,12 @@ $text-color: #444;
 
 $vpad: 20px;
 
+$table-bg: white;
+$table-cell-padding: 5px;
+$table-border-color: $bazel-green;
+$text-muted: $color-on-bazel-green;
+$line-height-base: 20px;
+$line-height-computed: 20px;
 
 html {
   position: relative;

--- a/_sass/tables.scss
+++ b/_sass/tables.scss
@@ -1,0 +1,64 @@
+// Bootstrap requires tables to carry a .table class in order for styling to
+// be applied. However, redcarpet emits table elements without the class and
+// it is not possible to customize it.
+//
+// Ideally, we would use a SASS directive to make the table element inherit
+// the formatting defined by the bootstrap templates... but we cannot do so
+// at the moment because we don't build bootstrap ourselves from its SASS
+// sources. Therefore, this file just borrows the minimal amount of code
+// from bootstrap 3.3.7 to render tables nicely.
+
+table {
+  background-color: $table-bg;
+}
+caption {
+  padding-top: $table-cell-padding;
+  padding-bottom: $table-cell-padding;
+  color: $text-muted;
+  text-align: left;
+}
+th {
+  text-align: left;
+}
+
+// Baseline styles
+
+table {
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: $line-height-computed;
+  // Cells
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        padding: $table-cell-padding;
+        line-height: $line-height-base;
+        vertical-align: top;
+        border-top: 1px solid $table-border-color;
+      }
+    }
+  }
+  // Bottom align for column headings
+  > thead > tr > th {
+    vertical-align: bottom;
+    border-bottom: 2px solid $table-border-color;
+  }
+  // Remove top border from thead by default
+  > caption + thead,
+  > colgroup + thead,
+  > thead:first-child {
+    > tr:first-child {
+      > th,
+      > td {
+        border-top: 0;
+      }
+    }
+  }
+  // Account for multiple tbody instances
+  > tbody + tbody {
+    border-top: 2px solid $table-border-color;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -5,5 +5,6 @@
 @import "footer.scss";
 @import "navbar.scss";
 @import "blog.scss";
+@import "tables.scss";
 
 @import "syntax.scss";


### PR DESCRIPTION
Import the minimal amount of code from Bootstrap in order to render tables
nicely in posts, which is necessary by the latest post on sandboxfs.

This is a bit of a hack: we should instead be building Bootstrap from its
SASS sources and then using a small custom rule to inherit those rules into
the elements that need them... but this looks non-trivial.