### PR TITLE
Enable comments on all posts and disable comments on archive page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,3 +18,11 @@ blog_site_url: https://blog.bazel.build
 docs_site_url: https://docs.bazel.build
 
 assets_url: https://bazel.build
+
+defaults:
+  - scope:
+      type: posts
+      path: '_posts'
+    values:
+      layout: posts
+      enable_comments: true

--- a/archive.html
+++ b/archive.html
@@ -1,6 +1,7 @@
 ---
 layout: posts
 title: Post Archive
+enable_comments: false
 ---
 
 <div>


### PR DESCRIPTION
This PR sets the default `enable_comments` metadata for all posts to true, therefore enabling Disqus comments on the individual post page. It also sets the layout to `posts` by default.

The Archive page does not need comments, so I've disabled it.