### PR TITLE
Enable comments on the Bazel 0.13.0 post

### DIFF
--- a/_posts/2018-05-02-bazel-0.13.md
+++ b/_posts/2018-05-02-bazel-0.13.md
@@ -1,6 +1,7 @@
 ---
 layout: posts
 title: "Bazel 0.13"
+enable_comments: true
 ---
 
 [Bazel 0.13](https://github.com/bazelbuild/bazel/releases/tag/0.13.0) has just


### PR DESCRIPTION
This is supposed to be enabled for all posts in https://github.com/bazelbuild/bazel-blog/commit/bdc24f640d54bd17f8d23c3c2131d750e4225b79

I'm not sure why Disqus still isn't showing up. Let's try enabling it manually on the post metadata.