### PR TITLE
Make the blog's front page readable

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,35 @@ title: Bazel Blog
   <div class="blog-post-meta">
     <span class="text-muted">{{ post.date | date_to_long_string }}</span>
   </div>
-  {{ post.content }}
+
+  <p>{{ post.excerpt | strip_html }}</p>
+
+  {% assign words = post.content | number_of_words %}
+  {% comment %}
+    According to https://en.wikipedia.org/wiki/Words_per_minute, the
+    average person can read about 180 WPM.
+  {% endcomment %}
+  {% assign minutes = words | divided_by:180 %}
+
+  <div class="blog-post-meta">
+    <span class="text-muted">
+      <a href="{{ post.url }}">Continue reading
+        {% if minutes <= 1 %}
+        (about 1 minute)
+        {% else %}
+        (about {{ minutes }} minutes)
+        {% endif %}
+      </a>
+      &middot;
+
+      <a href="{{ post.url }}#disqus_thread">
+        <span class="disqus-comment-count"
+              data-disqus-url="{{ post.url | prepend: site.blog_site_url }}">Comments</span>
+      </a>
+    </span>
+  </div>
 </div>
 
 {% endfor %}
+
+<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>


### PR DESCRIPTION
Our blog posts tend to be long... very long.  The previous blog index
page was showing the full posts, which made it completely unreadable.
It was impossible to quickly skim through the page looking for what
the newest posts are, as the post titles would be "clobbered" by all
the content.

This change makes the index page only show the post excerpts and adds
a little footer to each indicating how much longer they are and how
many comments they have.  This makes it trivial, at a quick glance,
to see what has recently been published.

This should also help the trends I have observed in which some people
hold onto posting a new entry because the new entry would eclipse
older content.