### PR TITLE
Display authors on the posts index and give them some more visibility

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,88 @@ defaults:
     values:
       layout: posts
       enable_comments: true
+
+authors:
+  asteinb:
+    - Alex Steinberg
+    - https://github.com/asteinb
+
+  brendandouglas:
+    - Brendan Douglas
+    - https://github.com/brendandouglas
+
+  cgrushko:
+    - Carmi Grushko
+    - https://github.com/cgrushko
+
+  cvcal:
+    - Chloe Calvarin
+    - https://github.com/cvcal
+
+  damienmg:
+    - Damien Martin-Guillerez
+    - https://github.com/damienmg
+
+  davidstanke:
+    - David Stanke
+    - https://github.com/davidstanke
+
+  dslomov:
+    - Dmitry Lomov
+    - https://github.com/dslomov
+
+  helenalt:
+    - Helen Altshuler
+    - https://github.com/helenalt
+
+  hermione521:
+    - Yue Gan
+    - https://github.com/hermione521
+
+  iirina:
+    - Irina Iancu
+    - https://github.com/iirina
+
+  jeffcox:
+    - Jeff Cox
+    - https://bazel.build/
+
+  jin:
+    - Jingwen Chen
+    - https://github.com/jin
+
+  jmmv:
+    - Julio Merino
+    - http://julio.meroh.net/
+
+  kchodorow:
+    - Kristina Chodorow
+    - https://www.kchodorow.com/
+
+  kevin1e100:
+    - Kevin Bierhoff
+    - https://github.com/kevin1e100
+
+  laszlocsomor:
+    - László Csomor
+    - https://github.com/laszlocsomor
+
+  laurentlb:
+    - Laurent Le Brun
+    - https://github.com/laurentlb
+
+  philwo:
+    - Philipp Wollermann
+    - https://github.com/philwo
+
+  russwolf:
+    - Russell Wolf
+    - https://github.com/russwolf
+
+  steren:
+    - Steren Giannini
+    - https://github.com/steren
+
+  ulfjack:
+    - Ulf Adams
+    - https://github.com/ulfjack

--- a/_includes/byline.html
+++ b/_includes/byline.html
@@ -1,0 +1,30 @@
+{% comment %}
+This include generates the byline of a post, which includes the post's date
+and the list of authors. The input parameters "date" and "authors" must be
+populated with the post's corresponding Front Matter fields.
+{% endcomment %}
+
+By
+{% assign last_pos=include.authors.size | minus: 1 %}
+{% assign and_pos=include.authors.size | minus: 2 %}
+{% for i in (0..last_pos) %}
+  {% assign author_id=include.authors[i] %}
+  {% assign author=site.authors[author_id] %}
+
+  {% if author %}
+    <a href="{{ author[1] }}">{{ author[0] }}</a>
+  {% else %}
+    {% comment %}
+    We found an invalid author. There is not much we can do other than just
+    dump the raw text. Do so and hope the author notices.
+    {% endcomment %}
+    {{ author_id }}
+  {% endif %}
+  {% if i == and_pos %}
+    and
+  {% elsif i < and_pos %}
+    ,
+  {% endif %}
+{% endfor %}
+
+on <span class="text-muted">{{ include.date | date_to_long_string }}</span>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -22,9 +22,7 @@ enable_comments: true
           <div class="blog-post">
             <h1 class="blog-post-title">{{ page.title }}</h1>
             <div class="blog-post-meta">
-              {% if page.date %}
-                <span class="text-muted">{{ page.date | date_to_long_string }}</a>
-              {% endif %}
+              {% include byline.html authors=page.authors date=page.date %}
             </div>
             <div class="blog-post-content">
               {{ content }}

--- a/_posts/2015-04-06-Simplified-Workspace-Creation.md
+++ b/_posts/2015-04-06-Simplified-Workspace-Creation.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Announcing simplified workspace creation
+authors:
+  - kchodorow
 ---
 
 To create a new workspace, you can now simply create an empty `WORKSPACE` file
@@ -35,5 +37,3 @@ setting up your workspace.
 Let us know if you have any questions or issues on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or
 [GitHub](https://github.com/bazelbuild/bazel).
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-04-10-bash-completion.md
+++ b/_posts/2015-04-10-bash-completion.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Support for Bash Shell Completion
+authors:
+  - damienmg
 ---
 
 We just pushed a support for [shell completion in the Bourne-Again
@@ -49,5 +51,3 @@ of two parts:
 Let us know if you have any questions or issues on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or
 [GitHub](https://github.com/bazelbuild/bazel).
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-04-15-share-your-project.md
+++ b/_posts/2015-04-15-share-your-project.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Tell us about your Bazel project!
+authors:
+  - kchodorow
 ---
 
 We're setting up a list of projects using Bazel. If you'd like us
@@ -16,5 +18,3 @@ the following information:
 
 If you don't want your project publicly listed, we'd still love to hear about
 it. Please [email us](mailto:bazel-core@googlegroups.com) directly and let us know.
-
-*By [Kristina Chodorow](https://www.kchodorow.com/)*

--- a/_posts/2015-04-22-thank-you-stickers.md
+++ b/_posts/2015-04-22-thank-you-stickers.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Stickers for Contributors
+authors:
+  - kchodorow
 ---
 
 <img src="/assets/bazel-stickers.jpg" alt="Bazel stickers" class="img-responsive">
@@ -18,5 +20,3 @@ Let us know if you've done any of the following and we'll send you stickers:
 * Are in the process of doing any of the things above.
 
 Thanks for your contributions, we really appreciate them.
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-06-17-visualize-your-build.md
+++ b/_posts/2015-06-17-visualize-your-build.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Visualize your build
+authors:
+  - kchodorow
 ---
 
 _Reposted from
@@ -65,5 +67,3 @@ Much neater!
 
 If you're interested in further refining your query, check out the
 [docs on querying]({{ site.docs_site_url }}/query.html).
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-06-25-ErrorProne.md
+++ b/_posts/2015-06-25-ErrorProne.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Checking your Java errors with Error Prone.
+authors:
+  - damienmg
 ---
 
 We recently open-sourced our support for [Error Prone](http://errorprone.info).
@@ -15,5 +17,3 @@ You can also tune the checks error-prone will perform by using the
 
 See the [documentation of Error Prone](http://errorprone.info/docs/installation) for more
 on Error Prone.
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-01-Configuration-File.md
+++ b/_posts/2015-07-01-Configuration-File.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Sharing your rc files
+authors:
+  - damienmg
 ---
 
 You can customize the options Bazel runs with in your `~/.bazelrc`, but
@@ -25,5 +27,3 @@ three paths to master rc files that are read in the following order:
   3. `/etc/bazel.bazelrc` (system-wide bazel rc file).
 
 The complete documentation on rc file is [here]({{ site.docs_site_url }}/bazel-user-manual.html#bazelrc).
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-08-Java-Configuration.md
+++ b/_posts/2015-07-08-Java-Configuration.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Configuring your Java builds
+authors:
+  - damienmg
 ---
 
 Let say that you want to build for Java 8 and errorprone checks off but
@@ -41,5 +43,3 @@ build --java_toolchain=//package:my_toolchain
 In the future, toolchain rules should be the configuration points for all
 the languages but it is a long road. We also want to make it easier to
 rebind the toolchain using the `bind` rule in the WORKSPACE file.
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-23-tree-trimming.md
+++ b/_posts/2015-07-23-tree-trimming.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Trimming your (build) tree
+authors:
+  - kchodorow
 ---
 
 _Reposted from [@kchodorow's blog](http://www.kchodorow.com/blog/2015/07/23/trimming-the-build-tree-with-bazel/)._
@@ -50,5 +52,3 @@ form, so the "maybe dirty" node will end up being marked as "yes, dirty" and
 re-evaluated (and so on up the tree).  However, Bazel's build graph lets you
 compile the bare minimum for a well-structured library, and in some cases avoid
 compilations altogether.
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2015-07-28-docker_build.md
+++ b/_posts/2015-07-28-docker_build.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Building deterministic Docker images with Bazel
+authors:
+  - damienmg
 ---
 
 [Docker](https://www.docker.com) images are great to automate your deployment
@@ -65,5 +67,3 @@ to fetch the various base image for the web and we are working on providing a
 
 You can learn more about this docker support
 [here](https://github.com/bazelbuild/docker_rules/blob/master/README.md).
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2015-07-29-dashboard-dogfood.md
+++ b/_posts/2015-07-29-dashboard-dogfood.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Build dashboard dogfood
+authors:
+  - kchodorow
 ---
 
 __WARNING__: This feature has been removed (2017-04-19).
@@ -35,5 +37,3 @@ for documentation.
 
 This is very much a work in progress. Please let us know if you have any
 questions, comments, or feedback.
-
-*By [Kristina Chodorow](https://www.kchodorow.com)

--- a/_posts/2015-09-01-beta-release.md
+++ b/_posts/2015-09-01-beta-release.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel Builder Blasts Beyond Beta Barrier
+authors:
+  - jeffcox
 ---
 
 _Reposted from [Google's Open Source blog](http://google-opensource.blogspot.com/2015/09/building-build-system-bazel-reaches-beta.html)._
@@ -45,5 +47,3 @@ and follow our [blog](http://bazel.build/blog) or
 free to contact us with questions or feedback on the
 [mailing list](https://groups.google.com/forum/#!forum/bazel-discuss) or IRC
 (#bazel on freenode).
-
-*By Jeff Cox, Bazel team*

--- a/_posts/2015-09-11-sandboxing.md
+++ b/_posts/2015-09-11-sandboxing.md
@@ -1,6 +1,9 @@
 ---
 layout: posts
 title: About Sandboxing
+authors:
+  - ulfjack
+  - philwo
 ---
 
 *This post was updated on 2017-12-19 to remove outdated information that caused
@@ -59,5 +62,3 @@ so far.
 
 On Windows, we currently do not implement sandboxing.
 
-
-*By [Ulf Adams](https://github.com/ulfjack)* and [Philipp Wollermann](https://github.com/philwo)

--- a/_posts/2015-12-10-java-workers.md
+++ b/_posts/2015-12-10-java-workers.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Persistent Worker Processes for Bazel
+authors:
+  - philwo
 ---
 
 Bazel runs most build actions as a separate process. Many build actions invoke a compiler.  However, starting a compiler is often slow: they have to perform some initialization when they start up, read the standard library, header files, low-level libraries, and so on. That’s why some compilers and tools have a persistent mode, e.g. [sjavac](http://openjdk.java.net/jeps/199), [Nailgun](http://martiansoftware.com/nailgun/) and [gcc server](http://per.bothner.com/papers/GccSummit03/gcc-server.pdf). Keeping a single process for longer and passing multiple individual requests to the same server can significantly reduce the amount of duplicate work and cut down on compile times.
@@ -15,5 +17,3 @@ We’ve tried the persistent JavaBuilder for a variety of builds and are seeing 
 If you often build Java code, we’d like you to give it a try. Just pass `--strategy=Javac=worker` to enable it or add `build --strategy=Javac=worker` to the .bazelrc in your home directory or in your workspace. Check the WorkerOptions class for [flags to further tune the workers’ behavior](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java) or run “bazel help” and look for the “Strategy options” category. Let us know how it works for you.
 
 We’re currently using a simple [protobuf-based protocol](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto) to communicate with the worker process. Let us know if you want to add support for more compilers; in many cases, you can do that without any Bazel changes. However, the protocol is still subject to change based on your feedback.
-
-*By [Philipp Wollermann](https://github.com/philwo)*

--- a/_posts/2015-3-27-Hello-World.md
+++ b/_posts/2015-3-27-Hello-World.md
@@ -1,9 +1,9 @@
 ---
 layout: posts
 title: Hello World
+authors:
+  - kchodorow
 ---
 
 Welcome to the Bazel blog!  We'll be using this forum for news and
 announcements.
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2016-01-27-continuous-integration.md
+++ b/_posts/2016-01-27-continuous-integration.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Using Bazel in a continuous integration system
+authors:
+  - damienmg
 ---
 
 When doing continuous integration, you do not want your build to fail because a
@@ -151,5 +153,3 @@ that summarizes the results of your tests. This test runner can be activated
 with the `--nolegacy_bazel_java_test` flag (this will soon be the default).
 Other tests also get [a basic XML output file](https://github.com/bazelbuild/bazel/blob/master/tools/test/test-setup.sh#L54)
 that contains only the result of the test (success or failure).
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-02-23-0.2.0-release.md
+++ b/_posts/2016-02-23-0.2.0-release.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel 0.2.0 Released
+authors:
+  - kchodorow
 ---
 
 We are delighted to announce the
@@ -99,5 +101,3 @@ shout-outs to the following contributors:
   effort into the Scala rules, as well as being a tireless supporter on Twitter.
 
 Thank you all, keep the discussion and bug reports coming!
-
-*By [Kristina Chodorow](https://www.kchodorow.com)*

--- a/_posts/2016-03-18-sandbox-easier-debug.md
+++ b/_posts/2016-03-18-sandbox-easier-debug.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Easier Debugging of Sandbox Failures
+authors:
+  - hermione521
 ---
 
 We have often heard that debugging failed execution due to issues with the sandbox is difficult and requires knowledge of the sandboxing code of Bazel to actually understand what’s happening. With [these changes](https://github.com/bazelbuild/bazel/commit/40ee9de052e3bb8cf5a59eeff3936148e1f55e69), we hope that you will be able to solve common issues easier on your own and make debugging easier.
@@ -56,5 +58,3 @@ There will be the same error message about not finding your compiler, but after 
 For this example, we run our compiler in the sandbox again manually and the error message shows `No command ‘some-compiler’ found` - looking around, you notice that the compiler binary is missing. This means it was not part of the action inputs, because Bazel always mounts all action inputs into the sandbox - so you check out your Skylark rule and notice that this is indeed the case. Adding your compiler to the input files in your Skylark rule should thus fix the error.
 
 Next time you run bazel build, it should mount your compiler into the sandbox and thus find it correctly. If you get a different error, you could repeat the steps above.
-
-*By [Yue Gan](https://github.com/hermione521)*

--- a/_posts/2016-03-31-autoconfiguration.md
+++ b/_posts/2016-03-31-autoconfiguration.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Using Skylark remote repositories to auto-detect the C++ toolchain.
+authors:
+  - damienmg
 ---
 
 [Skylark remote repositories](/docs/skylark/repository_rules.html) let you
@@ -87,5 +89,3 @@ When creating a Skylark remote repository, a few things should be taken in consi
    package rule, a good name would probably be `xxx_package` (e.g., `pypi_package`). If
    you create an autoconfiguration rule, `xxx_configure` is probably the best name
    (e.g. `cc_configure`).
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-06-10-0.3.0-release.md
+++ b/_posts/2016-06-10-0.3.0-release.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel 0.3.0 Released
+authors:
+  - damienmg
 ---
 
 We are delighted to announce the
@@ -89,5 +91,3 @@ shout-outs to the following contributors:
   their use of Bazel.
 
 Thank you all, keep the discussion and bug reports coming!
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2016-06-10-ide-support.md
+++ b/_posts/2016-06-10-ide-support.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: IDE support
+authors:
+  - dslomov
 ---
 
 One of Bazel’s longest-standing feature requests is integration with IDEs.
@@ -90,5 +92,3 @@ unnecessary build steps are performed.
 The aspect uses the
 [`java` provider]({{ site.docs_site_url }}/skylark/lib/JavaSkylarkApiProvider.html) on the targets
 it applies to to access a variety of information about Java targets.
-
-*By [Dmitry Lomov](https://github.com/dslomov)*

--- a/_posts/2016-10-07-bazel-windows.md
+++ b/_posts/2016-10-07-bazel-windows.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel on Windows
+authors:
+  - dslomov
 ---
 
 We first announced experimental Windows support in 0.3.0. Since then, we've
@@ -28,5 +30,3 @@ Now, we need your help! Please try building your Bazel project on Windows,
 and let us know what works or what doesn't work yet, and what we can do better.
 
 We are looking forward to what you build (on Windows)!
-
-*By [Dmitry Lomov](https://github.com/dslomov)*

--- a/_posts/2016-10-20-intellij-support.md
+++ b/_posts/2016-10-20-intellij-support.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: IntelliJ and Android Studio support
+authors:
+  - brendandouglas
 ---
 
 We've recently open-sourced Bazel plugins for
@@ -28,5 +30,3 @@ or build directly from [source](https://github.com/bazelbuild/intellij).
 Detailed docs are available [here](https://ij.bazel.build).
 
 The plugins are currently Linux-only, with plans for Mac support in the future.
-
-*By [Brendan Douglas](https://github.com/brendandouglas)*

--- a/_posts/2016-11-02-0.4.0-release.md
+++ b/_posts/2016-11-02-0.4.0-release.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel 0.4.0 Released
+authors:
+  - helenalt
 ---
 
 We are delighted to announce the [0.4.0 release of Bazel](https://github.com/bazelbuild/bazel/releases/tag/0.4.0).  This release marks major improvements in support for Windows, sandboxing and performance.
@@ -60,5 +62,3 @@ A big thank you to our community for your continued support.  Particular shout-o
 
 
 Thank you all, keep the discussion and bug reports coming!
-
-*By [Helen Altshuler](https://github.com/helenalt)*

--- a/_posts/2016-11-04-bazel-build.md
+++ b/_posts/2016-11-04-bazel-build.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: We are now bazel.build!
+authors:
+  - damienmg
 ---
 
 As you might have seen either in our
@@ -13,5 +15,3 @@ what Bazel is for: building!
 
 Our old domain, [bazel.io](https://bazel.io), will redirect to
 [bazel.build](https://bazel.build) for the forseenable future.
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-02-22-repository-invalidation.md
+++ b/_posts/2017-02-22-repository-invalidation.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Invalidation of repository rules
+authors:
+  - damienmg
 ---
 
 [Remote repositories]({{ site.docs_site_url }}/external.html) are the way to use dependencies from
@@ -86,5 +88,3 @@ the repositories.
 Therefore, if you think you should re-run if an environment variable changes (like
 for auto-configuration rules), you should declare those dependencies, or your user
 will have to do `bazel clean --expunge` each time they change their environment.
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Protocol Buffers in Bazel
+authors:
+  - cgrushko
 ---
 
 Bazel currently provides built-in rules for Java, JavaLite and C++.
@@ -206,5 +208,3 @@ directly mentioned by a `proto_library` rule; the collection of transitive
 descriptor sets is available through the `proto.transitive_descriptor_sets`
 Skylark provider. See [documentation in
 ProtoSourcesProvider](https://github.com/bazelbuild/bazel/blob/5dbb23ba44ec0037cf0944b17716ea3f08a69c27/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourcesProvider.java#L121).
-
-*By [Carmi Grushko](https://github.com/cgrushko)*

--- a/_posts/2017-02-28-google-summer-of-code.md
+++ b/_posts/2017-02-28-google-summer-of-code.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: A Google Summer of Code with Bazel
+authors:
+  - laurentlb
 ---
 
 I'm happy to announce that Bazel has been accepted as
@@ -26,6 +28,4 @@ most frequent questions.
 
 If you have any question, please contact us on bazel-core@googlegroups.com
 
-I'm looking forward to hearing from you,
-
-*By Laurent Le Brun, on behalf of the Bazel mentors.*
+I'm looking forward to hearing from you.

--- a/_posts/2017-03-07-java-sandwich.md
+++ b/_posts/2017-03-07-java-sandwich.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Skylark and Java rules interoperability
+authors:
+  - iirina
 ---
 
 As of Bazel 0.4.4, Java compilation is possible from a Skylark rule. This
@@ -186,5 +188,3 @@ Soon there will be support for use cases like this. Stay tuned!
 
 If you are interested in tracking the progress on Bazel Java sandwich you can
 subscribe to [this Github issue](https://github.com/bazelbuild/bazel/issues/2614).
-
-*By [Irina Iancu](https://github.com/iirina), on behalf of the Bazel Java team*

--- a/_posts/2017-03-21-design-of-skylark.md
+++ b/_posts/2017-03-21-design-of-skylark.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: A glimpse of the design of Skylark
+authors:
+  - laurentlb
 ---
 
 This blog post describes the design of Skylark, the language used to specify
@@ -92,5 +94,3 @@ read-only, i.e. you can iterate on an array, but not modify its elements. You
 may create a copy and modify it, though.
 
 In a future blog post, we'll take a look at the other features of the language.
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2017-04-21-JDK7-deprecation.md
+++ b/_posts/2017-04-21-JDK7-deprecation.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: JDK7 deprecation
+authors:
+  - damienmg
 ---
 
 The Bazel team has been maintaining a separate, stripped-down build of Bazel
@@ -47,5 +49,3 @@ Java team at Google, in particular
 
 Special thanks to [Philipp Wollermann](https://github.com/philwo) who made this
 new installer possible.
-
-*By [Damien Martin-Guillerez](https://github.com/damienmg)*

--- a/_posts/2017-05-26-Bazel-0-5-0-release.md
+++ b/_posts/2017-05-26-Bazel-0-5-0-release.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel 0.5.0 Released
+authors:
+  - steren
 ---
 
 We are delighted to announce the [0.5.0 release of
@@ -120,5 +122,3 @@ Thank you all, keep the
 reports](https://github.com/bazelbuild/bazel/issues) coming!
 
 See the full list of changes on [GitHub](https://github.com/bazelbuild/bazel/releases/tag/0.5.0).
-
-*By [Steren Giannini](https://github.com/steren)*

--- a/_posts/2017-05-31-google-summer-of-code-2017.md
+++ b/_posts/2017-05-31-google-summer-of-code-2017.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Google Summer of Code 2017
+authors:
+  - laurentlb
 ---
 
 Thank you very much to everyone who applied for [Google Summer of
@@ -20,5 +22,3 @@ proposal](https://docs.google.com/document/d/16FiwRfkwNlcaAysMChphr07WCKuvO6_6G9
 and follow [Harmandeep's blog](https://harmanio.wordpress.com/).
 
 A big thank you to everyone who applied!
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2017-06-28-sjd-unused_deps.md
+++ b/_posts/2017-06-28-sjd-unused_deps.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Strict Java Deps and `unused_deps`
+authors:
+  - cgrushko
 ---
 
 This blog post describes how Bazel implements "strict deps" for Java compilations ("SJD"), and how it is leveraged in [`unused_deps`](https://github.com/bazelbuild/buildtools/blob/799e530642bac55de7e76728fa0c3161484899f6/unused_deps/unused_deps.go), a tool to remove unused dependencies. It is my hope this knowledge will help write rules for similar JVM-based languages such as Scala and Kotlin.
@@ -53,5 +55,3 @@ This approach has the advantage that violations are easy to fix - Bazel tells th
 * Bazel passes all jars from the **transitive** dependencies of a rule.
 * Bazel notifies the SJD compiler plugin which jars are indirect.
 * During compilation, the compiler plugin reports any symbol mentioned in the Java file that is loaded from an indirect jar.
-
-*By [Carmi Grushko](https://github.com/cgrushko)*

--- a/_posts/2017-07-05-new-logo-and-homepage.md
+++ b/_posts/2017-07-05-new-logo-and-homepage.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: A new logo and homepage for Bazel
+authors:
+  - steren
 ---
 
 We are glad to unveil a new logo for Bazel:
@@ -28,5 +30,3 @@ By the way, feel free to suggest edits to our documentation, it is as easy as cl
 ![Edit button on Bazel docs](/assets/edit-button.png)
 
 We hope you like this new visual identity.
-
-*By [Steren Giannini](https://github.com/steren)*

--- a/_posts/2017-07-20-backward-compatibility.md
+++ b/_posts/2017-07-20-backward-compatibility.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Backward compatibility
+authors:
+  - laurentlb
 ---
 
 Bazel is in Beta and we are working hard towards Bazel 1.0 (see the
@@ -62,5 +64,3 @@ is unclear, please contact us and we will help you.
 To learn more about the changes we are doing, see the
 [backward compatibility page](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html).
 
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2017-08-25-introducing-sandboxfs.md
+++ b/_posts/2017-08-25-introducing-sandboxfs.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Introducing sandboxfs
+authors:
+  - jmmv
 ---
 
 **sandboxfs** is a new project to improve the way sandboxing works in Bazel
@@ -117,5 +119,3 @@ Enjoy!
 Special credits go to [Pallav Agarwal](https://github.com/pallavagarwal07),
 whom we had the pleasure of hosting over a summer internship in the Google
 NYC office and who wrote the initial version of sandboxfs.
-
-*By [Julio Merino](http://julio.meroh.net/)*

--- a/_posts/2017-09-25-conference-2017.md
+++ b/_posts/2017-09-25-conference-2017.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel Conference 2017
+authors:
+  - helenalt
 ---
 
 Bazel team is pleased to announce our first annual [**Bazel Conference**](https://sites.google.com/corp/bazel.build/conference2017), focused on the needs of our community. The conference will feature user stories and feedback, migration talks, roadmap, hands-on and break-out tech sessions with Bazel engineers, contributors and users.
@@ -16,5 +18,3 @@ Bazel team is pleased to announce our first annual [**Bazel Conference**](https:
 
 Register by October 15, as seating is limited and we won't allow walk-ins. Detailed schedule will be published mid October, and location details will be sent out to registered attendees.
 
-
-*By [Helen Altshuler](https://github.com/helenalt)*

--- a/_posts/2017-09-27-release-cadence.md
+++ b/_posts/2017-09-27-release-cadence.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: The New World of Bazel Releases
+authors:
+  - dslomov
 ---
 
 Bazel has been open-sourced exactly [2.5 years ago](https://blog.bazel.build/2015/03/27/Hello-World.html). It continues to be quite a journey, and we are very happy we have acquired some fellow travellers: [many projects, organizations and companies that we all know and love](https://sites.google.com/corp/bazel.build/conference2017/agenda) rely on Bazel every day.
@@ -27,5 +29,3 @@ As a result of this change, we now issue one minor release per month.
 
 Our [roadmap](https://bazel.build/roadmap.html) reflects our vision for Bazel 1.0 and beyond. We will
 annotate features on the roadmap with the release versions as those features get shipped.
-
-_By [Dmitry Lomov](https://github.com/dslomov)_

--- a/_posts/2017-10-03-conference-2017.md
+++ b/_posts/2017-10-03-conference-2017.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Bazel Conference 2017
+authors:
+  - helenalt
 ---
 
 Bazel team is pleased to announce our first annual [**Bazel Conference**](https://sites.google.com/corp/bazel.build/conference2017), focused on the needs of our community. The conference will feature user stories and feedback, migration talks, roadmap, hands-on and break-out tech sessions with Bazel engineers, contributors and users.
@@ -16,5 +18,3 @@ Bazel team is pleased to announce our first annual [**Bazel Conference**](https:
 
 Register by October 15, as seating is limited and we won't allow walk-ins. Detailed schedule will be published mid October, and location details will be sent out to registered attendees.
 
-
-*By [Helen Altshuler](https://github.com/helenalt)*

--- a/_posts/2017-10-16-windows-retrospect.md
+++ b/_posts/2017-10-16-windows-retrospect.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Bazel on Windows -- a year in retrospect"
+authors:
+  - laszlocsomor
 ---
 
 Bazel on Windows is no longer experimental. We think Bazel on Windows is now
@@ -57,5 +59,3 @@ platforms. We aim to maximize portability between host systems, so you get
 the same fast, correct builds on your developer OS of choice. If you run into
 any problems, please don't hesitate to
 [file a bug](https://github.com/bazelbuild/bazel/issues/new).
-
-*By [László Csomor](https://github.com/laszlocsomor)*

--- a/_posts/2017-12-11-thanks-bazelcon2017.md
+++ b/_posts/2017-12-11-thanks-bazelcon2017.md
@@ -1,6 +1,9 @@
 ---
 layout: posts
 title: Thank you for BazelCon 2017
+authors:
+  - helenalt
+  - davidstanke
 ---
 
 We are truly thankful to our community for making our first annual [Bazel Conference](https://sites.google.com/corp/bazel.build/conference2017) a success! Check out all the videos of all the talks from [**BazelCon 2017 on YouTube**](https://www.youtube.com/playlist?list=PLxNYxgaZ8RseY0KmkXQSt0StE71E7yizG).
@@ -47,7 +50,3 @@ What you can do next:
 * Join the discussion on bazel-discuss@googlegroups.com.
 
 We look forward to working with you and growing our Bazel user community in 2018!
-
-
-*By [Helen Altshuler](https://github.com/helenalt) and [David Stanke](https://github.com/davidstanke)*
-

--- a/_posts/2017-12-14-introducing-bazel-code-search.md
+++ b/_posts/2017-12-14-introducing-bazel-code-search.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Introducing Bazel Code Search
+authors:
+  - russwolf
 ---
 
 We are always looking for new ways to improve the experience of contributing to Bazel and helping users understanding how Bazel works. Today, we’re excited to share a preview of [Bazel Code Search](https://source.bazel.build), a major upgrade to Bazel’s code search site. This new site features a [refreshed user interface for code browsing](#browsing-through-bazel-repositories) and cross-repository [semantic search](#searching-the-bazel-codebase) with regular expression support, and a [navigable semantic index](#understanding-the-bazel-codebase-using-cross-references) of all definitions and references for the Bazel codebase. We’ve also updated the “Contribute” page on the Bazel website with [documentation for this tool](https://bazel.build/browse-and-search-user-guide.html). 
@@ -73,5 +75,3 @@ From the view of the repository, you can browse through folders and files in the
 We hope you’ll try [Bazel Code Search](https://source.bazel.build) and provide feedback through the “**!**” button in the top right of any page on the Bazel Code Search site. We would love to hear whether this tool helps you work with Bazel and what else you’d like to see Bazel Code Search offer. 
 
 Keep in mind that this project is still experimental and is subject to change.
-
-*By [Russell Wolf](https://github.com/russwolf)*

--- a/_posts/2018-01-19-config-parsing-order.md
+++ b/_posts/2018-01-19-config-parsing-order.md
@@ -1,6 +1,8 @@
 ---  
 layout: posts
 title: "Migration Help: --config parsing order"
+authors:
+  - cvcal
 ---  
 
 [`--config`](https://docs.bazel.build/versions/master/user-manual.html#config) expansion order is changing, in order to make it better align with user expectations, and to make layering of configs work as intended. To prepare for the change, please test your build with startup option `--expand_configs_in_place`.
@@ -307,5 +309,3 @@ Unfortunately, it gets worse, especially if you have the same config for differe
 
 To understand the order of your configs specifically, run Bazel as you normally would (remove targets for speed) with the option `--announce_rc`. The order in which the config expansions are output to the terminal is the order in which they are currently interpreted (again, between rc and command line). 
 
-
-*By [Chloe Calvarin](https://github.com/cvcal)*

--- a/_posts/2018-02-06-bazel-0.10.md
+++ b/_posts/2018-02-06-bazel-0.10.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Bazel 0.10"
+authors:
+  - laurentlb
 ---
 
 We're proud to announce the release of [Bazel 0.10](https://github.com/bazelbuild/bazel/releases/tag/0.10.0).
@@ -68,5 +70,3 @@ to suggest content for a next blog post.
 
 Discuss on [Hacker News](https://news.ycombinator.com/item?id=16317161) or
 [Reddit](https://www.reddit.com/r/bazel/comments/7vcm1l/bazel_010_released/).
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2018-02-14-how-android-builds-work-in-bazel.md
+++ b/_posts/2018-02-14-how-android-builds-work-in-bazel.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: How Android Builds Work in Bazel
+authors:
+  - asteinb
 ---
 
 ## Background: How Bazel Works
@@ -329,5 +331,3 @@ same as it would without ProGuard.
 is a way of rapidly building and deploying Android applications iteratively.
 It’s based off of `android_binary`, but has some additional functionality to
 make builds and deployments more incremental.
-
-*By [Alex Steinberg](https://github.com/asteinb)*

--- a/_posts/2018-02-26-bazel-0.11.md
+++ b/_posts/2018-02-26-bazel-0.11.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Bazel 0.11"
+authors:
+  - jin
 ---
 
 The Bazel team is happy to announce the release of [version 0.11.0](https://github.com/bazelbuild/bazel/releases/tag/0.11.0).
@@ -39,5 +41,3 @@ example.
 Did we miss anything? [Fill the form](https://docs.google.com/forms/d/e/1FAIpQLSde7NGMKA1xK2RZnOLk8XKm3A-Y09guJAFrkX35RCJxn3RB4w/viewform?usp=sf_link) to suggest content for a next blog post.
 
 Discuss on [Hacker News](https://news.ycombinator.com/item?id=16468244) or [Reddit](https://www.reddit.com/r/bazel/comments/80focy/bazel_011/).
-
-*By [Jingwen Chen](https://github.com/jin)*

--- a/_posts/2018-02-28-incremental-dexing.md
+++ b/_posts/2018-02-28-incremental-dexing.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Scalable Android Builds with Incremental Dexing"
+authors:
+  - kevin1e100
 ---
 
 Bazel supports building Android apps with Java and C++ code out of the box through the
@@ -69,5 +71,3 @@ files that are larger than necessary.  That means you want to turn off increment
 you’re building a binary that you want to give to users, but it can speed up your development and
 test builds every day with no known adverse effect.  Plus, we expect this to get better since
 Android Studio has started to use a similar scheme to build Android apps in Gradle.
-
-*By [Kevin Bierhoff](https://github.com/kevin1e100)*

--- a/_posts/2018-04-11-bazel-0.12.md
+++ b/_posts/2018-04-11-bazel-0.12.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Bazel 0.12"
+authors:
+  - laurentlb
 ---
 
 We've just released [Bazel 0.12](https://github.com/bazelbuild/bazel/releases/tag/0.12.0)!
@@ -64,5 +66,3 @@ If you use Bazel on Windows, please tell us what you think! We've set up [a surv
 Did we miss anything? [Fill the form](https://docs.google.com/forms/d/e/1FAIpQLSde7NGMKA1xK2RZnOLk8XKm3A-Y09guJAFrkX35RCJxn3RB4w/viewform?usp=sf_link) to suggest content for a next blog post.
 
 Discuss on [Hacker News](https://news.ycombinator.com/item?id=16812955).
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/_posts/2018-04-13-preliminary-sandboxfs-support.md
+++ b/_posts/2018-04-13-preliminary-sandboxfs-support.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: Preliminary sandboxfs support and performance results
+authors:
+  - jmmv
 ---
 
 [Back in August of 2017]({% post_url 2017-08-25-introducing-sandboxfs %}), we
@@ -165,5 +167,3 @@ sandboxing as a blocker for enabling it. We are very interested in knowing what
 kind of impact this has on your builds so that we can assess how important it is
 to continue working on this. Please give the instructions above a try and let us
 know how it goes! And also, let us know if you want to contribute!
-
-*By [Julio Merino](http://julio.meroh.net/)*

--- a/_posts/2018-05-02-bazel-0.13.md
+++ b/_posts/2018-05-02-bazel-0.13.md
@@ -1,6 +1,8 @@
 ---
 layout: posts
 title: "Bazel 0.13"
+authors:
+  - laurentlb
 ---
 
 [Bazel 0.13](https://github.com/bazelbuild/bazel/releases/tag/0.13.0) has just
@@ -71,5 +73,3 @@ been released!
 
 
 Discuss on [Hacker News](https://news.ycombinator.com/item?id=16982301).
-
-*By [Laurent Le Brun](https://github.com/laurentlb)*

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@ title: Bazel Blog
 <div class="blog-post">
   <h1 class="blog-post-title"><a href="{{ post.url }}">{{ post.title }}</a></h1>
   <div class="blog-post-meta">
-    <span class="text-muted">{{ post.date | date_to_long_string }}</span>
+    <span class="text-muted">
+      {% include byline.html authors=post.authors date=post.date %}
+    </span>
   </div>
 
   <p>{{ post.excerpt | strip_html }}</p>


### PR DESCRIPTION
This change moves the information about post authorship to the post's
Front Matter instead of having it as a hardcoded paragraph at the end.
This allows programmatic access to the authorship information, which
we then use to display author names in the post index and more
prominently next to the post title.

To ensure author details are always consistent (name and URL), this
moves all people data to a table in _config.yml and references it
using usernames from the Front Matter.