### PR TITLE
GDPR Compliance: Add link to Google Privacy Policy to Bazel Blog Footer

### DIFF
--- a/_includes/footer-content.html
+++ b/_includes/footer-content.html
@@ -3,10 +3,11 @@
     <div class="col-sm-4 col-md-2">
       <p>About</p>
       <ul class="list-unstyled">
-        <li><a href="https://github.com/bazelbuild/bazel/wiki/Bazel-Users">Who's using Bazel</a></li>
+        <li><a href="https://github.com/bazelbuild/bazel/wiki/Bazel-Users">Who's Using Bazel?</a></li>
         <li><a href="{{ site.main_site_url }}/roadmap.html">Roadmap</a></li>
         <li><a href="{{ site.main_site_url }}/contributing.html">Contribute</a></li>
         <li><a href="{{ site.main_site_url }}/governance.html">Governance Plan</a></li>
+        <li><a href="https://policies.google.com/privacy">Privacy Policy</a></li>
       </ul>
     </div>
     <div class="col-sm-4 col-md-2">


### PR DESCRIPTION
Add a link to the Google Privacy Policy to the Bazel Blog footer.