### PR TITLE
disable disqus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ defaults:
       path: '_posts'
     values:
       layout: posts
-      enable_comments: true
+      enable_comments: false
 
 authors:
   aehlig:

--- a/_config.yml
+++ b/_config.yml
@@ -19,13 +19,14 @@ docs_site_url: https://docs.bazel.build
 
 assets_url: https://bazel.build
 
+enable_comments: false # disqus comments disabled because they're flaky
+
 defaults:
   - scope:
       type: posts
       path: '_posts'
     values:
       layout: posts
-      enable_comments: false # disqus comments disabled because they're flaky
 
 authors:
   aehlig:

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ defaults:
       path: '_posts'
     values:
       layout: posts
-      enable_comments: false
+      enable_comments: false # disqus comments disabled because they're flaky
 
 authors:
   aehlig:

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -1,6 +1,6 @@
 ---
 nav: blog
-enable_comments: true
+enable_comments: false
 ---
 
 

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -1,6 +1,5 @@
 ---
 nav: blog
-enable_comments: false
 ---
 
 

--- a/index.html
+++ b/index.html
@@ -31,17 +31,17 @@ title: Bazel Blog
         (about {{ minutes }} minutes)
         {% endif %}
       </a>
-	  {% comment %} /* disqus disabled b/c it's flaky (and we're not sure if it's useful) */
+	  {% if page.enable_comments %} 
       &middot;
       <a href="{{ post.url }}#disqus_thread">
         <span class="disqus-comment-count"
               data-disqus-url="{{ post.url | prepend: site.blog_site_url }}">Comments</span>
       </a>
-	  {% endcomment %}
+	  {% endif %}
     </span>
   </div>
 </div>
 
 {% endfor %}
 
-{% comment %}<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>{% endcomment %}
+{% if page.enable_comments %}<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>{% endif %}

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ title: Bazel Blog
         (about {{ minutes }} minutes)
         {% endif %}
       </a>
-	  {% if page.enable_comments %} 
+	  {% if site.enable_comments %} 
       &middot;
       <a href="{{ post.url }}#disqus_thread">
         <span class="disqus-comment-count"
@@ -44,4 +44,4 @@ title: Bazel Blog
 
 {% endfor %}
 
-{% if page.enable_comments %}<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>{% endif %}
+{% if site.enable_comments %}<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>{% endif %}

--- a/index.html
+++ b/index.html
@@ -31,16 +31,17 @@ title: Bazel Blog
         (about {{ minutes }} minutes)
         {% endif %}
       </a>
+	  {% comment %} /* disqus disabled b/c it's flaky (and we're not sure if it's useful) */
       &middot;
-
       <a href="{{ post.url }}#disqus_thread">
         <span class="disqus-comment-count"
               data-disqus-url="{{ post.url | prepend: site.blog_site_url }}">Comments</span>
       </a>
+	  {% endcomment %}
     </span>
   </div>
 </div>
 
 {% endfor %}
 
-<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>
+{% comment %}<script id="dsq-count-scr" src="//googlebazel.disqus.com/count.js" async></script>{% endcomment %}


### PR DESCRIPTION
The disqus comment feature appears to be not consistently enabled (looks like a problem with the publishing pipeline). Moreover, we're not sure it's really a useful feature. The bazel-discuss mailing list is where we like to talk.

Disabling comments pending further, um, discussion.