### PR TITLE
Fixed phrasing for contributor attributions

### DIFF
--- a/_posts/2018-09-14-bazel-0.17.md
+++ b/_posts/2018-09-14-bazel-0.17.md
@@ -108,6 +108,6 @@ Did we miss anything? [Fill the form](https://docs.google.com/forms/d/e/1FAIpQLS
 
 ## Thank you to our contributors!
 
-This release contains contributions from many people at Google, including Alex Beggs, Arielle Albon, Austin Schuh, Benjamin Peterson, Bin Lu, Clint Harrison, Dan Fabulich, David Ostrovsky, David Pursehouse, Ed Baunton, Ed Schouten, George Gensure, Gregor Jasny, Loo Rong Jie, Rishabh Chakrabarti, Robert Gay, Stephan Pleines, Taras Tsugrii, Vladimir Zaytsev, Wayou Liu, wylazy, and Yannic Bonenberger.
+This release contains contributions from many people at Google, as well as: Alex Beggs, Arielle Albon, Austin Schuh, Benjamin Peterson, Bin Lu, Clint Harrison, Dan Fabulich, David Ostrovsky, David Pursehouse, Ed Baunton, Ed Schouten, George Gensure, Gregor Jasny, Loo Rong Jie, Rishabh Chakrabarti, Robert Gay, Stephan Pleines, Taras Tsugrii, Vladimir Zaytsev, Wayou Liu, wylazy, and Yannic Bonenberger.
 
 Thank you to everyone who contributed to this release!


### PR DESCRIPTION
The current phrasing sounds like our contributors work at Google.