### PR TITLE
Fix discovery of RSS feed

### DIFF
--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -5,7 +5,7 @@
           <h2>Discuss</h2>
           <p>Join the discussion on our <a href="https://groups.google.com/forum/#!forum/bazel-discuss">mailing list</a>.</p>
           <h2>Subscribe</h2>
-          <p>Subscribe to our blog via the <a href="/feed.xml">RSS Feed</a> or via email:</p>
+          <p>Subscribe to our blog via the <a rel="alternate" type="application/rss+xml" href="/feed.xml">RSS Feed</a> or via email:</p>
           <div class="well">
             <form action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri=BazelBlog', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true">
               <div class="form-group">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,7 +36,7 @@
     </script>
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
-    <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Bazel Blog" href="/feed.xml">
 
     <!-- Webfont -->
     <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,6 +36,7 @@
     </script>
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
+    <link rel="alternate" type="application/rss+xml" href="/feed.xml">
 
     <!-- Webfont -->
     <link href="//fonts.googleapis.com/css?family=Roboto:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">


### PR DESCRIPTION
Some apps, when given a link to a blog page, can discover the RSS feed automatically based on the presence of a `<link>` tag in the head or rel/type attributes on an `<a>` within the page. These commits add the necessary tag and attributes for this to work on the Bazel blog.

The value in the `title` attribute is what is typically presented to users, so may need to adjusted if 'Bazel Blog' is not desired.