### PR TITLE
Add Ed Baunton as bazel blog post author

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,10 @@ authors:
     - Dmitry Lomov
     - https://github.com/dslomov
 
+  edbaunton:
+    - Ed Baunton
+    - https://github.com/edbaunton
+
   helenalt:
     - Helen Altshuler
     - https://github.com/helenalt


### PR DESCRIPTION
As discussed with @helenalt we were hoping to contribute a bazel blog post about the hackathon - I think my name needs to be here if I were to post it under my name; although I don't think there are any non-Googlers already.