### PR TITLE
Fix 0.20.0 announcement blog post markdown errors

### DIFF
--- a/_posts/2018-12-14-Bazel-0.20.0.md
+++ b/_posts/2018-12-14-Bazel-0.20.0.md
@@ -11,17 +11,18 @@ With this release, we communicate [breaking changes](https://docs.google.com/doc
 following our [communication policy](https://docs.google.com/document/d/1q5GGRxKrF_mnwtaPKI487P8OdDRh2nN7jX6U-FXnHL0/).
 
 [Breaking changes in 0.20](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.20):
-  - [--incompatible_remove_native_http_archive](https://github.com/bazelbuild/bazel/issues/6570)
-   - [--incompatible_remove_native_git_repository](https://github.com/bazelbuild/bazel/issues/6569)
-   - [--incompatible_disable_cc_toolchain_label_from_crosstool_proto](https://github.com/bazelbuild/bazel/issues/6434)
-   - [--incompatible_disable_depset_in_cc_user_flags](https://github.com/bazelbuild/bazel/issues/6384)
-   - [--incompatible_disable_cc_configuration_make_variables](https://github.com/bazelbuild/bazel/issues/6381)
-   - [--incompatible_disallow_conflicting_providers](https://github.com/bazelbuild/bazel/issues/5902)
-   - [--incompatible_range_type](https://github.com/bazelbuild/bazel/issues/5264)
+
+  - [`--incompatible_remove_native_http_archive`](https://github.com/bazelbuild/bazel/issues/6570)
+  - [`--incompatible_remove_native_git_repository`](https://github.com/bazelbuild/bazel/issues/6569)
+  - [`--incompatible_disable_cc_toolchain_label_from_crosstool_proto`](https://github.com/bazelbuild/bazel/issues/6434)
+  - [`--incompatible_disable_depset_in_cc_user_flags`](https://github.com/bazelbuild/bazel/issues/6384)
+  - [`--incompatible_disable_cc_configuration_make_variables`](https://github.com/bazelbuild/bazel/issues/6381)
+  - [`--incompatible_disallow_conflicting_providers`](https://github.com/bazelbuild/bazel/issues/5902)
+  - [`--incompatible_range_type`](https://github.com/bazelbuild/bazel/issues/5264)
 
 Changes for which 0.20 is a migration window are marked with [GitHub label 'migration-0.20'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Amigration-0.20)
  
-Breaking changes in the next release (0.21 )[are marked with GitHub label 'breaking-change-0.21'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.21)
+Breaking changes in the next release (0.21)[are marked with GitHub label 'breaking-change-0.21'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.21)
 
 ## General Changes
 
@@ -38,42 +39,42 @@ Breaking changes in the next release (0.21 )[are marked with GitHub label 'break
 
 ## C++
 
-  - The --experimental_no_dotd_scanning_with_modules command line argument is not supported anymore.
-  - The --prune_cpp_modules command line option is not supported anymore.
-  - The --experimental_prune_cpp_input_discovery command line option is not supported anymore.
-  - All cc_toolchains depended on from cc_toolchain_suite.toolchains are now analyzed when not using
-    platforms in order to select the right cc_toolchain.
-  - CROSSTOOL file is now read from the package of cc_toolchain, not from
-    the package of cc_toolchain_suite. This is not expected to break anybody since
-    cc_toolchain_suite and cc_toolchain are commonly in the same package.
-  - All cc_toolchains dependent on from cc_toolchain_suite.toolchains are now analyzed when not using
-    platforms in order to select the right cc_toolchain.
+  - The `--experimental_no_dotd_scanning_with_modules` command line argument is not supported anymore.
+  - The `--prune_cpp_modules` command line option is not supported anymore.
+  - The `--experimental_prune_cpp_input_discovery` command line option is not supported anymore.
+  - All `cc_toolchains` depended on from `cc_toolchain_suite.toolchains` are now analyzed when not using
+    platforms in order to select the right `cc_toolchain`.
+  - CROSSTOOL file is now read from the package of `cc_toolchain`, not from
+    the package of `cc_toolchain_suite`. This is not expected to break anybody since
+    `cc_toolchain_suite` and `cc_toolchain` are commonly in the same package.
+  - All `cc_toolchains` dependent on from `cc_toolchain_suite.toolchains` are now analyzed when not using
+    platforms in order to select the right `cc_toolchain`.
     
 ## Java
 
   - The`--explicit_jre_deps` flag is rempoved.
   - If the `--javabase` flag is unset, Bazel locates a JDK using the `JAVA_HOME` environment variable 
     and searching the PATH. If no JDK is found, `--javabase` is empty and builds targeting Java
-    will not be supported. Previously Bazel would fall back to using the embedded  JDK as a --javabase,
+    will not be supported. Previously Bazel would fall back to using the embedded  JDK as a `--javabase`,
     but this is no longer default behaviour. A JDK should be explicitly installed instead to enable Java development.
 
 ## Android
 
   - Added support for Android NDK r18.
-  - Make legacy-test-support ("legacy_test-<api-level>") from
-    android_sdk_repository neverlink. The legacy test support
+  - Make legacy-test-support (`legacy_test-<api-level>`) from
+    `android_sdk_repository` neverlink. The legacy test support
     libraries shouldn't be built into test binaries. To make them
     available at runtime, developers should declare them via
     uses-library:
     https://developer.android.com/training/testing/set-up-project#android-test-base
     
  ## Starlark
-  - All overrides of Starlark's ctx.new_file function are now
+  - All overrides of Starlark's `ctx.new_file` function are now
     deprecated. Try the `--incompatible_new_actions_api` flag to ensure your
     code is forward-compatible.
   - The function `attr.license` is deprecated. It can be disabled now
     with `--incompatible_no_attr_license`.
-  - The 'default' parameter of attr.output and attr.output_list has been removed. This is controlled by
+  - The 'default' parameter of `attr.output` and `attr.output_list` has been removed. This is controlled by
     `--incompatible_no_output_attr_default`
   - A number of platform-related Starlark APIs which were previously
     marked "experimental" are now disabled by default, and may be

--- a/_posts/2018-12-14-Bazel-0.20.0.md
+++ b/_posts/2018-12-14-Bazel-0.20.0.md
@@ -22,7 +22,7 @@ following our [communication policy](https://docs.google.com/document/d/1q5GGRxK
 
 Changes for which 0.20 is a migration window are marked with [GitHub label 'migration-0.20'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Amigration-0.20)
  
-Breaking changes in the next release (0.21)[are marked with GitHub label 'breaking-change-0.21'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.21)
+Breaking changes in the next release (0.21) [are marked with GitHub label 'breaking-change-0.21'](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+label%3Abreaking-change-0.21)
 
 ## General Changes
 


### PR DESCRIPTION
It seems like the markdown parser for the blog posts treats any `_` as start of an italics block.

<img width="803" alt="screen shot 2018-12-17 at 10 58 57 am" src="https://user-images.githubusercontent.com/1469579/50108727-dd66fd00-01ea-11e9-94a6-c97f0800c812.png">

<img width="675" alt="screen shot 2018-12-17 at 10 58 54 am" src="https://user-images.githubusercontent.com/1469579/50108716-d63fef00-01ea-11e9-95eb-23077aeaa924.png">

This PR fixes the formatting by wrapping all `_` withs code blocks.