### PR TITLE
Document the change in HTTP_PROXY handling in Bazel 0.21.

### DIFF
--- a/_posts/2018-12-19-bazel-0.21.md
+++ b/_posts/2018-12-19-bazel-0.21.md
@@ -103,6 +103,12 @@ Breaking changes in the next release (0.22) are marked with GitHub label
     now also logs updateActionResult. This is the Remote Execution API call used
     in remote caching, so now remote caching
     [can be debugged](https://github.com/bazelbuild/tools_remote/) using the grpc log.
+*   The deprecated flavors of `http_archive()`, `http_file()`,
+    `git_repository()`, etc. no longer respect the `HTTP_PROXY` and
+    `HTTPS_PROXY` environment variables. Support for this was removed to
+    prevent interference with GRPC,
+    [causing remote builds to fail](https://github.com/bazelbuild/bazel/pull/6340).
+    The non-deprecated flavors of these functions should work as intended.
 
 ## Community
 


### PR DESCRIPTION
I think this change was important enough that it should have ended up in
the release notes. Unfortunately, I wasn't fully aware that this was
accomplished through 'Relnotes' tags in commit messages.