### PR TITLE
Specify PATH via the --action_env flag when building the blog

### DIFF
--- a/scripts/cloudbuild.yaml
+++ b/scripts/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel-jekyll', 'scripts']
 - name: gcr.io/$PROJECT_ID/bazel-jekyll
-  args: ['build', '--action_env=PATH=/usr/local/bin:/usr/bin:/bin', '//site']
+  args: ['build', '--action_env=PATH=/usr/local/bin:/usr/bin:/bin', '//:site']
 - name: gcr.io/cloud-builders/gsutil
   args: ['-m', 'rsync', '-r', '-c', '-d', '/workspace/bazel-bin/site-build', 'gs://blog.bazel.build']
 - name: gcr.io/cloud-builders/gsutil

--- a/scripts/cloudbuild.yaml
+++ b/scripts/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['build', '--tag=gcr.io/$PROJECT_ID/bazel-jekyll', 'scripts']
 - name: gcr.io/$PROJECT_ID/bazel-jekyll
-  args: ['build', '//:site']
+  args: ['build', '--action_env=PATH=/usr/local/bin:/usr/bin:/bin', '//site']
 - name: gcr.io/cloud-builders/gsutil
   args: ['-m', 'rsync', '-r', '-c', '-d', '/workspace/bazel-bin/site-build', 'gs://blog.bazel.build']
 - name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
Otherwise all builds with Bazel >=0.21.0 fail with

src/main/tools/linux-sandbox-pid1.cc:427: "execvp(jekyll, 0x22e4a20)": No such file or directory