### PR TITLE
Remove note about aapt being deprecated in favour of aapt2.

### DIFF
--- a/_posts/2019-07-10-bazel-0.28.md
+++ b/_posts/2019-07-10-bazel-0.28.md
@@ -22,9 +22,6 @@ We’ve just released [Bazel 0.28](https://github.com/bazelbuild/bazel/releases/
 
 ## Android
 
-
-
-*   aapt is deprecated in favor of aapt2.
 *   Fixed treatment of `<dist:module />` tags in AndroidManifest.xml.
 *   Fixed treatment of AndroidManifest.xml attributes which contained XML escaping.
 *   Fixed asset precedence for `android_binary` rules with aapt2.


### PR DESCRIPTION
Nothing has been changed on the Bazel side yet.