### PR TITLE
Update protocol buffers blogpost for the deprecation of native Protobuf rules

### DIFF
--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -77,7 +77,7 @@ http_archive(
 )
 
 # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite//:javalite_toolchain,
-# which is the JavaLite proto runtime (base classes and common utilities).    # which is the JavaLite proto runtime (base classes and common utilities).
+# which is the JavaLite proto runtime (base classes and common utilities).
 http_archive(
     name = "com_google_protobuf_javalite",
     sha256 = "a8cb9b8db16aff743a4bc8193abec96cf6ac0b0bc027121366b43ae8870f6fd3",

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -27,10 +27,6 @@ By making a `java_library` (resp. `cc_library`) depend on `java_proto_library`
 > [https://github.com/cgrushko/proto_library](https://github.com/cgrushko/proto_library)
 > contains a buildable example.
 
-<!-- TODO(yannic): Remove this when cgrushko/proto_library is updated.
-     https://github.com/cgrushko/proto_library/pull/15 -->
-> **Update (August 2019)**: The example above is outdated and does no longer work. [https://github.com/Yannic/proto_library](https://github.com/Yannic/proto_library) contains an updated example.
-
 ### WORKSPACE file
 
 Bazel's proto rules implicitly depend on the

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -7,7 +7,8 @@ authors:
 
 Bazel currently provides rules for Java, JavaLite and C++.
 
-<!-- TODO(yannic): Create documentation for rules_proto and link to that instead. -->
+<!-- TODO(yannic): Create documentation for rules_proto and link to that instead. 
+     https://github.com/bazelbuild/bazel/issues/9203 -->
 [`proto_library`]({{ site.docs_site_url }}/be/protocol-buffer.html#proto_library)
 is a language-agnostic rule that describes relations between `.proto` files.
 
@@ -54,7 +55,7 @@ http_archive(
     ],
 )
 
-# rules_cc defines rules for generating Java code from Protocol Buffers.
+# rules_java defines rules for generating Java code from Protocol Buffers.
 http_archive(
     name = "rules_java",
     sha256 = "ccf00372878d141f7d5568cedc4c42ad4811ba367ea3e26bc7c43445bbc52895",

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -36,10 +36,10 @@ The following satisfies these dependencies:
 
 > TIP: Clone [https://github.com/cgrushko/proto_library](https://github.com/cgrushko/proto_library) to try protobufs in Bazel now.
 
-<!-- TODO(yannic): The necessary fixes are not in a release yet, update when 3.10 drops. -->
-> **Update (August 2019)**: If you're using Bazel 1.0 or later, the minimum Protocol Buffer version required is [ee4f2492ea4e7ff120f68a792af870ee30435aa5](https://github.com/protocolbuffers/protobuf/commit/ee4f2492ea4e7ff120f68a792af870ee30435aa5).
+> **Update (August 2019)**: We strongly recommend to use
+[Protocol Buffer version 3.10](https://github.com/protocolbuffers/protobuf/releases/tag/v3.10.0-rc1)
+ar later to maximize compatibility with future Bazel releases.
 
-<!-- TODO(yannic): Update protobuf-javalite to include load statements for @rules_{cc,java,proto,python}. -->
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -80,10 +80,10 @@ http_archive(
 # which is the JavaLite proto runtime (base classes and common utilities).
 http_archive(
     name = "com_google_protobuf_javalite",
-    sha256 = "a8cb9b8db16aff743a4bc8193abec96cf6ac0b0bc027121366b43ae8870f6fd3",
-    strip_prefix = "protobuf-fa08222434bc58d743e8c2cc716bc219c3d0f44e",
+    sha256 = "311b29b8d0803ab4f89be22ff365266abb6c48fd3483d59b04772a144d7a24a1",
+    strip_prefix = "protobuf-7b64714af67aa967dcf941df61fe5207975966be",
     urls = [
-        "https://github.com/google/protobuf/archive/fa08222434bc58d743e8c2cc716bc219c3d0f44e.zip",
+        "https://github.com/google/protobuf/archive/7b64714af67aa967dcf941df61fe5207975966be.zip",
     ],
 )
 

--- a/_posts/2017-02-27-protocol-buffers.md
+++ b/_posts/2017-02-27-protocol-buffers.md
@@ -27,8 +27,9 @@ By making a `java_library` (resp. `cc_library`) depend on `java_proto_library`
 > [https://github.com/cgrushko/proto_library](https://github.com/cgrushko/proto_library)
 > contains a buildable example.
 
-<!-- TODO(yannic): Remove this when cgrushko/proto_library is updated. -->
-> **Update (August 2019)**: The example above is outdated and will no longer work with Bazel 1.0 or later. [https://github.com/Yannic/proto_library](https://github.com/Yannic/proto_library) contains an updated example.
+<!-- TODO(yannic): Remove this when cgrushko/proto_library is updated.
+     https://github.com/cgrushko/proto_library/pull/15 -->
+> **Update (August 2019)**: The example above is outdated and does no longer work. [https://github.com/Yannic/proto_library](https://github.com/Yannic/proto_library) contains an updated example.
 
 ### WORKSPACE file
 
@@ -39,50 +40,59 @@ The following satisfies these dependencies:
 
 > TIP: Clone [https://github.com/cgrushko/proto_library](https://github.com/cgrushko/proto_library) to try protobufs in Bazel now.
 
-> **Update (January 2019)**: If you're using Bazel 0.21.0 or later, the minimum Protocol Buffer version required is [**3.6.1.2**](https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.1.2). See this [pull request](https://github.com/protocolbuffers/protobuf/pull/4650) for more information. 
+<!-- TODO(yannic): The necessary fixes are not in a release yet, update when 3.10 drops. -->
+> **Update (August 2019)**: If you're using Bazel 1.0 or later, the minimum Protocol Buffer version required is [ee4f2492ea4e7ff120f68a792af870ee30435aa5](https://github.com/protocolbuffers/protobuf/commit/ee4f2492ea4e7ff120f68a792af870ee30435aa5).
 
-<!-- TODO(yannic): The necessary fixes are not in a release yet. -->
-> **Update (August 2019)**: If you're using Bazel 1.0 or later, the minimum Protocol Buffer version required is [**???**](https://github.com/protocolbuffers/protobuf/releases/tag/v???). **TODO(yannic): The fixes are not in a release yet**
-
+<!-- TODO(yannic): Update protobuf-javalite to include load statements for @rules_{cc,java,proto,python}. -->
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # rules_cc defines rules for generating C++ code from Protocol Buffers.
 http_archive(
     name = "rules_cc",
-    sha256 = "???",
-    strip_prefix = "rules_cc-???",
+    sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
+    strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/???.tar.gz",
-        "https://github.com/bazelbuild/rules_cc/archive/???.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
+        "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
     ],
 )
 
 # rules_cc defines rules for generating Java code from Protocol Buffers.
 http_archive(
     name = "rules_java",
-    sha256 = "???",
-    strip_prefix = "rules_java-???",
+    sha256 = "ccf00372878d141f7d5568cedc4c42ad4811ba367ea3e26bc7c43445bbc52895",
+    strip_prefix = "rules_java-d7bf804c8731edd232cb061cb2a9fe003a85d8ee",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/???.tar.gz",
-        "https://github.com/bazelbuild/rules_java/archive/???.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/d7bf804c8731edd232cb061cb2a9fe003a85d8ee.tar.gz",
+        "https://github.com/bazelbuild/rules_java/archive/d7bf804c8731edd232cb061cb2a9fe003a85d8ee.tar.gz",
     ],
 )
 
 # rules_proto defines abstract rules for building Protocol Buffers.
 http_archive(
     name = "rules_proto",
-    sha256 = "???",
-    strip_prefix = "rules_proto-???",
+    sha256 = "57001a3b33ec690a175cdf0698243431ef27233017b9bed23f96d44b9c98242f",
+    strip_prefix = "rules_proto-9cd4f8f1ede19d81c6d48910429fe96776e567b1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/???.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/???.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/9cd4f8f1ede19d81c6d48910429fe96776e567b1.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/9cd4f8f1ede19d81c6d48910429fe96776e567b1.tar.gz",
     ],
 )
 
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+# java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite//:javalite_toolchain,
+# which is the JavaLite proto runtime (base classes and common utilities).    # which is the JavaLite proto runtime (base classes and common utilities).
+http_archive(
+    name = "com_google_protobuf_javalite",
+    sha256 = "a8cb9b8db16aff743a4bc8193abec96cf6ac0b0bc027121366b43ae8870f6fd3",
+    strip_prefix = "protobuf-fa08222434bc58d743e8c2cc716bc219c3d0f44e",
+    urls = [
+        "https://github.com/google/protobuf/archive/fa08222434bc58d743e8c2cc716bc219c3d0f44e.zip",
+    ],
+)
+
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 rules_cc_dependencies()
-rules_cc_toolchains()
 
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 rules_java_dependencies()
@@ -91,17 +101,6 @@ rules_java_toolchains()
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()
 rules_proto_toolchains()
-
-# java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite//:javalite_toolchain,
-# which is the JavaLite proto runtime (base classes and common utilities).
-#
-# TODO(yannic): Update this to a version that includes the load statements for rules_{cc,java,proto,python}.
-http_archive(
-    name = "com_google_protobuf_javalite",
-    sha256 = "d8a2fed3708781196f92e1e7e7e713cf66804bd2944894401057214aff4f468e",
-    strip_prefix = "protobuf-5e8916e881c573c5d83980197a6f783c132d4276",
-    urls = ["https://github.com/google/protobuf/archive/5e8916e881c573c5d83980197a6f783c132d4276.zip"],
-)
 ```
 
 ### BUILD files

--- a/_posts/2019-10-01-protobuf-updates.md
+++ b/_posts/2019-10-01-protobuf-updates.md
@@ -1,0 +1,10 @@
+---
+layout: posts
+title: "Update on using Protocol Buffers in Bazel"
+authors:
+  - Yannic
+---
+
+We’re pleased to announce that we updated the instructions for using 
+[Protocol Buffers in Bazel](https://events.withgoogle.com/bazelcon-2019/)
+to reflect recent and upcoming changes to Bazel.

--- a/_posts/2019-10-01-protobuf-updates.md
+++ b/_posts/2019-10-01-protobuf-updates.md
@@ -6,5 +6,5 @@ authors:
 ---
 
 We’re pleased to announce that we updated the instructions for using 
-[Protocol Buffers in Bazel](https://events.withgoogle.com/bazelcon-2019/)
+[Protocol Buffers in Bazel](/2017/02/27/protocol-buffers.html)
 to reflect recent and upcoming changes to Bazel.


### PR DESCRIPTION
Fixes #188 

TODO before this can be merged:
  - [x] Push updated example to https://github.com/Yannic/proto_library and/or update https://github.com/cgrushko/proto_library
  - [x] Fill-in missing fields to load `@rules{cc,java,proto}`
  - [x] Make design doc for Starlark rewrite public and add it to proposals repo
  - [x] ~~Ask whether Protobuf can cut a release that includes the changes. They partly agreed to do a Bazel-only release here: https://github.com/protocolbuffers/protobuf/pull/6438#issuecomment-514880746~~ (Won't happen until 3.10?)