### PR TITLE
Add 'id' field to headers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ destination: production
 
 markdown: redcarpet
 redcarpet:
-  extensions: ["tables"]
+  extensions: ["tables", "with_toc_data"]
 
 paginate: 10
 


### PR DESCRIPTION
Turns a header like `<h2>Other Important Changes</h2>` into `<h2 id="other-important-changes">Other Important Changes</h2>` to enable linking to particular parts of a blog post.

I've `jekyll serve`d the site locally and the CSS looks pretty janky (see below), but the `id` feilds are added correctly with this config change.


![image](https://user-images.githubusercontent.com/12058921/78958127-919c3d80-7b2a-11ea-8800-aa8d0a1f7786.png)
