### PR TITLE
Add AnchorJS to post headers

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -49,5 +49,12 @@ nav: blog
 
     {% include footer.html %}
     {% include blog-twitter-js.html %}
+
+    <!-- Anchor JS -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js"></script>
+    <script>
+      // Automatically add anchors and links to all header elements that don't already have them.
+      anchors.add();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This adds an automatic link for headers in blogposts.

![Screen Shot 2020-04-10 at 5 37 29 PM](https://user-images.githubusercontent.com/347918/78981193-fdde6780-7b51-11ea-8752-dbd3d9a0f0e9.png)
