### PR TITLE
Update Bazel 3.2 release notes

### DIFF
--- a/_posts/2020-05-27-bazel-3-2.md
+++ b/_posts/2020-05-27-bazel-3-2.md
@@ -27,12 +27,6 @@ Bazel 3.2 is not a major release. As such, updating from Bazel 3.1 is expected t
 * Added `aquery_differ_v2` that works with the new aquery proto output format.
 
 
-## C++
-
-* Restore case-sensitivity to `-I` and `/I` include scanning detection to avoid conflicts.
-* Improve include scanner support for `cl.exe` and `clang-cl` command lines.
-
-
 ## Other changes
 
 * Add new flag `--experimental_no_product_name_out_symlink`. When enabled, the `bazel-out` symlink won’t be created if a different name is given to `--symlink_prefix`.


### PR DESCRIPTION
Update Bazel 3.2 release notes to remove include scanning reference.