### PR TITLE
add.aiuto

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,10 @@ authors:
     - Klaus Aehlig
     - https://github.com/aehlig
 
+  aiuto:
+    - Tony Aiuto
+    - https://github.com/aiuto
+
   asteinb:
     - Alex Steinberg
     - https://github.com/asteinb


### PR DESCRIPTION
Make my name show up correctly when it appears as the author of a blog post.