### PR TITLE
fix: update 5.0 post with breaking change

### DIFF
--- a/_posts/2022-01-19-bazel-5.0.md
+++ b/_posts/2022-01-19-bazel-5.0.md
@@ -23,6 +23,7 @@ Bazel 5.0 is a major release and Bazel’s [second LTS release](https://blog.baz
 * Bazel will no longer create a `bazel-out` symlink if `--symlink_prefix` is specified: the directory pointed to via the `bazel-out` symlink is accessible via `${symlink_prefix}-out`.
 * Removed flag `--experimental_no_product_name_out_symlink`; it is effectively always true.
 * Removed `--action_graph` from the `dump` command.
+* Removed `--incompatible_restrict_string_escapes` from the `build` command.
 * Removed `--{experimental_,}json_trace_compression`; its value is determined by the profile name.
 * Removed `--experimental_profile_cpu_usage`; it is effectively always true.
 * `--legacy_dynamic_scheduler` is now a no-op.


### PR DESCRIPTION
`--incompatible_restrict_string_escapes` was removed
[here](https://github.com/bazelbuild/bazel/commit/21b4b1a489c991682b9fcc9a10b468b9ea18e931)

cc @Wyverald 

see https://github.com/bazelbuild/bazel/pull/14695