### PR TITLE
Add blog post for release 5.4

### DIFF
--- a/_posts/2022-12-06-bazel-5.4.md
+++ b/_posts/2022-12-06-bazel-5.4.md
@@ -1,0 +1,19 @@
+---
+layout: posts
+title: "Bazel 5.4"
+authors:
+  - keertk
+---
+
+Bazel 5.4.0 is a minor LTS release. It is fully backward compatible with Bazel 5.0 and contains selected changes by the Bazel community and Google engineers.
+
+* Added `rlocationpath(s)` functions suitable for the `Rlocation` function offered by runfiles libraries for smoother transition from Bazel 5.x.x to Bazel 6.0.0 ([#16668](https://github.com/bazelbuild/bazel/pull/16668))
+* `package(default_package_metadata=[...])` is now the preferred alternative to `default_applicable_liceneses`. `default_applicable_liceneses` will be removed in a future release. ([#16892](https://github.com/bazelbuild/bazel/pull/16892))
+* Fixed hanging issue when Bazel fails to upload action inputs. ([#16819](https://github.com/bazelbuild/bazel/pull/16819))
+* Upgraded google-auth-library-oauth2-http dependencies and fixed transitive dependency on opencensus-contrib-http-util 0.31.0. ([#15639](https://github.com/bazelbuild/bazel/issues/15639))
+* Fixed coverage generation for C++ when multiple files with the same name are present. ([#16672](https://github.com/bazelbuild/bazel/pull/16672))
+* Moved analysis_test into testing.analysis_test, an experimental function intended to be used only by the rules_testing repository. The move makes it easier to support both Bazel 5.4.0 and Bazel 6.0.0. ([#16702](https://github.com/bazelbuild/bazel/pull/16702))
+
+## Acknowledgments
+
+This release contains contributions from many people at Google, as well as Andreas Fuchs, Benjamin Peterson, Brentley Jones, Dan Fleming, Danny Wolf, Emil Kattainen, Fabian Meumertzheim, Juh-Roch, Keith Smiley, Krzysztof Naglik, Niyas Sait, Noa Resare, Oliver Eikemeier, Peter Mounce, Philipp Schrader, Ryan Beasley, Thi Doãn, Yannic, Zhongpeng Lin.


### PR DESCRIPTION
Tracking issue: https://github.com/bazelbuild/bazel/issues/16663
Expected publish date: 2022-12-13