### PR TITLE
Delete FeedBurner widget

### DIFF
--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -5,18 +5,7 @@
           <h2>Discuss</h2>
           <p>Join the discussion on our <a href="https://groups.google.com/forum/#!forum/bazel-discuss">mailing list</a>.</p>
           <h2>Subscribe</h2>
-          <p>Subscribe to our blog via the <a rel="alternate" type="application/rss+xml" href="/feed.xml">RSS Feed</a> or via email:</p>
-          <div class="well">
-            <form action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('https://feedburner.google.com/fb/a/mailverify?uri=BazelBlog', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true">
-              <div class="form-group">
-                <input type="text" class="form-control" name="email" placeholder="name@email.com">
-              </div>
-              <input type="hidden" value="BazelBlog" name="uri">
-              <input type="hidden" name="loc" value="en_US">
-              <button type="submit" class="btn btn-primary btn-block">Subscribe</button>
-            </form>
-            <p>Delivered by <a href="https://feedburner.google.com" target="_blank">FeedBurner</a></p>
-          </div>
+          <p>Subscribe to our blog via the <a rel="alternate" type="application/rss+xml" href="/feed.xml">RSS Feed</a>.
           <h2>Contribute</h2>
           <p>The source for this blog can be found on <a href="https://github.com/bazelbuild/bazel-blog">GitHub</a>.</p>
           <h2>Archive</h2>


### PR DESCRIPTION
Apparently FeedBurner has been in maintenance mode for quite some time now.

Fixes https://github.com/bazelbuild/bazel-blog/issues/289