### PR TITLE
Fix jekyll serve shebang

### DIFF
--- a/scripts/jekyll_build.sh.tpl
+++ b/scripts/jekyll_build.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 HOST="${HOST-localhost}"
 PORT="${PORT-12345}"
 RUNFILES=$(cd ${JAVA_RUNFILES-$0.runfiles}/%{workspace_name} && pwd -P)


### PR DESCRIPTION
This uses bash-only features (specifically I saw errors with the `function` declarations), so be honest that this wants bash.