### PR TITLE
Point documentation link in header/footer link to new Bazel docs page.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ gems: [jekyll-paginate]
 main_site_url: https://bazel.build
 blog_site_url: https://blog.bazel.build
 docs_site_url: https://docs.bazel.build
+new_docs_site_url: https://bazel.build/docs
 
 assets_url: https://bazel.build
 

--- a/_includes/footer-content.html
+++ b/_includes/footer-content.html
@@ -15,7 +15,7 @@
       <ul class="list-unstyled">
         <li><a href="http://stackoverflow.com/questions/tagged/bazel">Stack Overflow</a></li>
         <li><a href="https://github.com/bazelbuild/bazel/issues">Issue Tracker</a></li>
-        <li><a href="{{ site.docs_site_url }}">Documentation</a></li>
+        <li><a href="{{ site.new_docs_site_url }}">Documentation</a></li>
         <li><a href="{{ site.main_site_url }}/faq.html">FAQ</a></li>
         <li><a href="{{ site.main_site_url }}/support.html">Support Policy</a></li>
       </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,7 +33,7 @@
           </form>
           <ul class="nav navbar-nav navbar-right">
             <li{% if page.nav == "docs" %} class="active"{% endif %}>
-              <a href="{{ site.docs_site_url }}">Documentation</a>
+              <a href="{{ site.new_docs_site_url }}">Documentation</a>
             </li>
             <li{% if page.nav == "contribute" %} class="active"{% endif %}>
               <a href="{{ site.main_site_url }}/contributing.html">Contribute</a>


### PR DESCRIPTION
Fixes #350.